### PR TITLE
ENG-878: fixing action docs, typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Run Terraform Action from oak-terraform-actions
-        uses: oaknational/oak-terrform-actions/actions/terraform-checks@main
+        uses: oaknational/oak-terraform-actions/actions/terraform-checks/action.yml@main
 ```
 
 For more details, visit the [Oak Terraform Actions repository](https://github.com/oaknational/oak-terraform-actions).
 
-# commitlint
+# Commitlint
 
 We're using [husky](https://github.com/typicode/husky) to create pre-commit hooks with commitlint and the [conventional commit plugin](https://github.com/conventional-changelog/commitlint).
 

--- a/examples/general-use/README.md
+++ b/examples/general-use/README.md
@@ -23,9 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Terraform Action from oak-terraform-actions
-        uses: oaknational/oak-terraform-actions/actions/terraform@main
-        with:
-          example_input: "value"
+        uses: oaknational/oak-terraform-actions/actions/terraform-checks/action.yml@main
 ```
 
 ### Explanation


### PR DESCRIPTION
## Description

- From working on the search-api separately, the action is wrong in the examples. 
- Commitlint should be capitalised

## Issue(s)

[ENG-878](https://www.notion.so/oaknationalacademy/Add-Commit-Lint-Husky-into-Terraform-Actions-Repo-71007b3423a04ffb9dc142317eacd7f6?pvs=4)

## How to test

1. Tested elsewhere

