### PR TITLE
fix(ENG-884): removing sonar from semantic release since irrelevant

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  branches: ["main", "ENG-884"],
+  branches: ["main"],
   plugins: [
     // Analyse commits.
     // https://github.com/semantic-release/commit-analyzer/#rules-definition
@@ -24,19 +24,11 @@ module.exports = {
         changelogFile: "CHANGE_LOG.md",
       },
     ],
-    // Bump the version number in the sonar-project.properties file.
-    [
-      "@semantic-release/exec",
-      {
-        prepareCmd:
-          "node ./scripts/release/change_sonarcloud_project_version.js v${nextRelease.version}",
-      },
-    ],
     // Commit the change log and the updated SonarCloud project version number.
     [
       "@semantic-release/git",
       {
-        assets: ["CHANGE_LOG.md", "sonar-project.properties"],
+        assets: ["CHANGE_LOG.md"],
         // Note, this isn't a string literal, it's a Mustache-style template.
         message: "build(release v${nextRelease.version}): See CHANGE_LOG.md",
       },


### PR DESCRIPTION
## Description

1. Removing feature branch from semantic release
2. Removing sonar from release file as not needed

## Issue(s)

[ENG-884](https://www.notion.so/oaknationalacademy/Add-Semantic-Release-to-Github-Actions-c0c9f8e6d0ed43858b44e01972ae881d)

## How to test

1. Merge, re-run pipeline

## Checklist

- [ ] Something that needs doing
