### PR TITLE
[ENG-966] Make base dir an input variable

### DIFF
--- a/actions/terraform-checks/action.yml
+++ b/actions/terraform-checks/action.yml
@@ -1,6 +1,11 @@
 ---
 name: "Terraform Checks"
 description: "Perform common Terraform checks"
+inputs:
+  terraform_base_dir:
+    description: Which base dir to search for the Terraform config(s) in
+    required: false
+    default: infrastructure
 runs:
   using: "composite"
   steps:
@@ -40,7 +45,7 @@ runs:
 
     - name: "Run TFLint"
       shell: bash
-      run: tflint --chdir infrastructure/ --recursive
+      run: tflint --chdir ${{ inputs.terraform_base_dir }}/ --recursive
 
     - name: "Ascertain Terraform Version"
       shell: bash
@@ -49,13 +54,13 @@ runs:
     - name: "Checking Terraform Format of Files"
       shell: bash
       run: |
-        cd infrastructure
+        cd ${{ inputs.terraform_base_dir }}
         terraform fmt -check $(find . -name '*tf')
 
     - name: "Validate Terraform Configs"
       shell: bash
       run: |
-        cd infrastructure
+        cd ${{ inputs.terraform_base_dir }}
         for d in $(find . -type d -mindepth 1 -maxdepth 1)
         do
           echo "Validating the $d config"


### PR DESCRIPTION
## Description

- Allow non default base dirs

## Issue(s)

[ENG-966](https://www.notion.so/oaknationalacademy/Add-the-Terraform-CI-to-the-modules-repo-10a26cc4e1b18008a3befe1a74022a8d?pvs=4)

## How to test

1. Run in another repo with a different directory set e.g. https://github.com/oaknational/oak-terraform-modules/actions/runs/11013152792/job/30581146159 (it fails, as expected, but with `lstat modules/: no such file or directory`)
2. Run again without the `terraform_base_dir` set and check that still works e.g. https://github.com/oaknational/Cloud-Config/actions/runs/11014013454/job/30583656010

## Checklist
