### PR TITLE
Revert "feat: ignore vercel_deployment in drift detection"

### DIFF
--- a/actions/terraform-vercel-drift/action.yml
+++ b/actions/terraform-vercel-drift/action.yml
@@ -1,30 +1,30 @@
-name: "Vercel Drift Detection"
-description: "Detects drift between Terraform Cloud state and actual Vercel infrastructure"
+name: 'Vercel Drift Detection'
+description: 'Detects drift between Terraform Cloud state and actual Vercel infrastructure'
 
 inputs:
   TF_API_TOKEN:
-    description: "Terraform Cloud API token"
+    description: 'Terraform Cloud API token'
     required: true
   TF_CLOUD_ORGANIZATION:
-    description: "Terraform Cloud organization name"
+    description: 'Terraform Cloud organization name'
     required: true
   TF_WORKSPACE:
-    description: "Terraform Cloud workspace name"
+    description: 'Terraform Cloud workspace name'
     required: true
   TF_BASE_DIRECTORY:
     default: "infrastructure/project"
   SLACK_WEBHOOK_URL:
-    description: "Slack webhook URL for notifications"
+    description: 'Slack webhook URL for notifications'
     required: true
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Set global ENV vars
       shell: bash
       run: |
-        echo "TF_API_TOKEN=${{ inputs.TF_API_TOKEN }}" >> $GITHUB_ENV
-        echo "TF_CLOUD_ORGANIZATION=${{ inputs.TF_CLOUD_ORGANIZATION }}" >> $GITHUB_ENV
+          echo "TF_API_TOKEN=${{ inputs.TF_API_TOKEN }}" >> $GITHUB_ENV
+          echo "TF_CLOUD_ORGANIZATION=${{ inputs.TF_CLOUD_ORGANIZATION }}" >> $GITHUB_ENV
 
     - name: Upload Configuration
       uses: hashicorp/tfc-workflows-github/actions/upload-configuration@v1.3.2
@@ -49,31 +49,17 @@ runs:
       with:
         plan: ${{ fromJSON(steps.plan-run.outputs.payload).data.relationships.plan.data.id }}
 
-    - name: Filter Deployment Changes
-      id: filter-changes
-      shell: bash
-      run: |
-        PLAN_ID="${{ steps.plan-output.outputs.plan_id }}"
-
-        PLAN_JSON=$(curl -s -H "Authorization: Bearer ${{ inputs.TF_API_TOKEN }}" \
-             -H "Content-Type: application/vnd.api+json" \
-             --location \
-             "https://app.terraform.io/api/v2/plans/$PLAN_ID/json-output")
-
-        FILTERED_ADD=$(echo "$PLAN_JSON" | jq '[.resource_changes[]? | select(.change.actions[] == "create" and .type != "vercel_deployment")] | length')
-        echo "add=$FILTERED_ADD" >> $GITHUB_OUTPUT
-
     - name: Check for Drift
       id: check-drift
       shell: bash
       run: |
-        ADD="${{ steps.filter-changes.outputs.add }}"
+        ADD="${{ steps.plan-output.outputs.add }}"
         CHANGE="${{ steps.plan-output.outputs.change }}"
         DESTROY="${{ steps.plan-output.outputs.destroy }}"
 
         if [ "$ADD" -gt 0 ] || [ "$CHANGE" -gt 0 ] || [ "$DESTROY" -gt 0 ]; then
           DRIFT_DETECTED="true"
-          echo "Drift detected! $ADD to add, $CHANGE to change, $DESTROY to destroy (excluding vercel_deployment)"
+          echo "Drift detected! $ADD to add, $CHANGE to change, $DESTROY to destroy"
         else
           DRIFT_DETECTED="false"
           echo "No drift detected. Infrastructure matches Terraform configuration."
@@ -85,7 +71,7 @@ runs:
       if: steps.check-drift.outputs.drift_detected == 'true'
       shell: bash
       run: |
-        ADD="${{ steps.filter-changes.outputs.add }}"
+        ADD="${{ steps.plan-output.outputs.add }}"
         CHANGE="${{ steps.plan-output.outputs.change }}"
         DESTROY="${{ steps.plan-output.outputs.destroy }}"
         TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
@@ -142,7 +128,7 @@ runs:
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": "*Action Required:*\n1. Review the drift details in Terraform Cloud\n2. Ignore the Vercel_deployment addition shown in the plan\n3. Determine if the manual changes should be:\n   - Codified in Terraform, or\n   - Reverted by applying Terraform"
+                  "text": "*Action Required:*\n1. Review the drift details in Terraform Cloud\n2. Determine if the manual changes should be:\n   - Codified in Terraform, or\n   - Reverted by applying Terraform"
                 }
               },
               {


### PR DESCRIPTION

## Description

- This reverts commit 74531028e29e7209fe1b94d9cf45916fcbf4d175. 
We've added lifecycle to ignore vercel-`deployment` in the module, we no longer need to filter the plan-output.


## Issue(s)

[ENG-1464](https://www.notion.so/oaknationalacademy/Fix-vercel_deployment-false-positive-in-drift-detection-30326cc4e1b180b785adf880cc1d1bab)

## How to test

1. ....

## Checklist

- [ ] Something that needs doing
