### PR TITLE
[ENG-1485] Cleanup vercel drift workflow

### DIFF
--- a/actions/terraform-vercel-drift/action.yml
+++ b/actions/terraform-vercel-drift/action.yml
@@ -13,8 +13,11 @@ inputs:
     required: true
   TF_BASE_DIRECTORY:
     default: "infrastructure/project"
-  SLACK_WEBHOOK_URL:
-    description: 'Slack webhook URL for notifications'
+  SLACK_BOT_TOKEN:
+    description: 'Slack bot token for notifications'
+    required: true
+  VERCEL_DRIFT_SLACK_CHANNEL_ID:
+    description: 'Slack channel ID to send drift alerts to'
     required: true
 
 runs:
@@ -80,6 +83,7 @@ runs:
 
         PAYLOAD=$(cat <<-EOF
         {
+            "channel": "${{ inputs.VERCEL_DRIFT_SLACK_CHANNEL_ID }}",
             "text": "🚨 Terraform Drift Detected",
             "blocks": [
               {
@@ -153,6 +157,7 @@ runs:
         echo "Generated Payload:"
         echo "$PAYLOAD"
 
-        curl -X POST \
-          -H 'Content-type: application/json' \
-          --data "${PAYLOAD}" ${{ inputs.SLACK_WEBHOOK_URL }}
+        curl -X POST https://slack.com/api/chat.postMessage \
+        -H "Authorization: Bearer ${{ inputs.SLACK_BOT_TOKEN }}" \
+        -H 'Content-type: application/json; charset=utf-8' \
+        --data "${PAYLOAD}"


### PR DESCRIPTION
## Description

- Switched from Slack webhook url to Slack bot as the url is tied my account. See [here](https://docs.slack.dev/messaging/sending-messages-using-incoming-webhooks/#:~:text=That%20URL%20is%20your%20shiny%20new%20incoming%20webhook%2C%20one%20that%27s%20specific%20to%20a%20single%20user%20and%20a%20single%20channel.) and [here](https://docs.slack.dev/authentication/tokens/#:~:text=Bot%20tokens%20represent%20a%20bot,is%20usually%20for%20the%20best.) 

## Issue(s)

[ENG-1485](https://www.notion.so/oaknationalacademy/Clean-up-Vercel-drift-workflow-31926cc4e1b1808296f3c6db066d8b80)

## How to test

1. ....

## Checklist

- [ ] Something that needs doing
