### PR TITLE
feat: Terraform Linter Part 2 - Core [ENG-1498]

### DIFF
--- a/oak-terraform-linter/README.md
+++ b/oak-terraform-linter/README.md
@@ -1,0 +1,72 @@
+# oak-terraform-linter
+
+A custom rule-based linter for Terraform code.
+
+## Features
+
+- **Rule-based validation**: Define custom linting rules in TypeScript
+- **JSON configuration**: Configure which rules to apply via JSON files
+- **Actionable suggestions**: Rules can provide remediation suggestions
+- **Extensibility**: Implement and register custom rules
+- **Strict mode**: Treat warnings as errors for CI/CD pipelines
+- **Environment-aware**: Rules can access execution context (e.g., private repo flag)
+
+## Installation
+
+```bash
+npm install
+npm run build
+```
+
+## Quick Start
+
+### Run with Defaults
+
+```bash
+npm run linter -- --path ./path/to/terraform
+```
+
+### Use Custom Rules
+
+```bash
+npm run linter -- --path ./path/to/terraform --rules ./path/to/my-rules.json
+```
+
+### Strict Mode (fails on warnings)
+
+```bash
+npm run linter -- --path ./path/to/terraform --strict
+```
+
+### Production
+
+```bash
+# assuming 'npm run build'
+node ./dist/index.js --path ./path/to/terraform --rules ./path/to/my-rules.json
+```
+
+### Inspect HCL2 JSON Structure
+
+```bash
+npm run parse -- --file ./your-terraform.tf
+```
+
+Use this to understand the parsed structure when authoring rules.
+
+## Documentation
+
+- [Rule Authoring Guide](src/rules/RULE_AUTHORING.md) - Create custom rules
+- [Examples](examples/README.md) - Sample configurations and Terraform files
+- [Parse Command](src/commands/parse/README.md) - Parse any Terraform file and output it as JSON
+
+## Architecture
+
+The linter is built around four core components:
+
+1. **Parser** (`src/core/parser.ts`) - Converts HCL to JSON using @cdktf/hcl2json
+2. **Rules Engine** (`src/rules/engine.ts`) - Loads and executes rules against the parsed HCL
+3. **Rule Loader** (`src/rules/loader.ts`) - Instantiates rules (optionally from configuration files)
+4. **Reporters** (`src/reporters/`) - Formats and outputs results
+
+Rules are implemented as TypeScript classes that process the parsed HCL.
+

--- a/oak-terraform-linter/src/cli.ts
+++ b/oak-terraform-linter/src/cli.ts
@@ -46,9 +46,7 @@ export async function runCLI(argv: string[]): Promise<number> {
       isPrivateRepo: args["private-repo"] as boolean,
     };
 
-    const allViolations = contexts.flatMap((ctx) =>
-      engine.executeRules(ctx, executionContext),
-    );
+    const allViolations = contexts.flatMap((ctx) => engine.executeRules(ctx, executionContext));
 
     const reporter = new HumanReporter();
     reporter.report(allViolations, {

--- a/oak-terraform-linter/src/cli.ts
+++ b/oak-terraform-linter/src/cli.ts
@@ -1,0 +1,68 @@
+import yargs from "yargs";
+import { TerraformParser } from "./core/parser";
+import { RulesEngine } from "./rules/engine";
+import { HumanReporter } from "./reporters/human";
+import { ExecutionContext } from "./core/types";
+
+export async function runCLI(argv: string[]): Promise<number> {
+  const args = await yargs(argv)
+    .option("path", {
+      alias: "p",
+      type: "string",
+      description: "Path to Terraform directory or file",
+      required: true,
+    })
+    .option("rules", {
+      alias: "r",
+      type: "string",
+      description: "Path to rules configuration file (JSON)",
+    })
+    .option("strict", {
+      alias: "s",
+      type: "boolean",
+      default: false,
+      description: "Treat warnings as errors",
+    })
+    .option("private-repo", {
+      type: "boolean",
+      default: false,
+      description: "Flag indicating if the repository is private",
+    })
+    .help()
+    .parseAsync();
+
+  try {
+    const parser = new TerraformParser();
+    const contexts = await parser.parseDirectory(args.path as string);
+
+    const engine = new RulesEngine();
+    if (args.rules) {
+      await engine.loadRules(args.rules as string);
+    } else {
+      engine.loadDefaultRules();
+    }
+
+    const executionContext: ExecutionContext = {
+      isPrivateRepo: args["private-repo"] as boolean,
+    };
+
+    const allViolations = contexts.flatMap((ctx) => engine.executeRules(ctx, executionContext));
+
+    const reporter = new HumanReporter();
+    reporter.report(allViolations, {
+      strict: args.strict as boolean,
+      fileCount: contexts.length,
+    });
+
+    const hasErrors = allViolations.some((v) => v.severity === "error");
+    const hasWarnings = allViolations.some((v) => v.severity === "warning");
+
+    if (hasErrors) return 1;
+    if (hasWarnings && args.strict) return 1;
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Error: ${message}`);
+    return 1;
+  }
+}

--- a/oak-terraform-linter/src/cli.ts
+++ b/oak-terraform-linter/src/cli.ts
@@ -46,7 +46,9 @@ export async function runCLI(argv: string[]): Promise<number> {
       isPrivateRepo: args["private-repo"] as boolean,
     };
 
-    const allViolations = contexts.flatMap((ctx) => engine.executeRules(ctx, executionContext));
+    const allViolations = contexts.flatMap((ctx) =>
+      engine.executeRules(ctx, executionContext),
+    );
 
     const reporter = new HumanReporter();
     reporter.report(allViolations, {

--- a/oak-terraform-linter/src/cli.ts
+++ b/oak-terraform-linter/src/cli.ts
@@ -28,12 +28,19 @@ export async function runCLI(argv: string[]): Promise<number> {
       default: false,
       description: "Flag indicating if the repository is private",
     })
+    .option("no-recursive", {
+      type: "boolean",
+      default: false,
+      description: "Disable recursive directory search (only search root directory)",
+    })
     .help()
     .parseAsync();
 
   try {
     const parser = new TerraformParser();
-    const contexts = await parser.parseDirectory(args.path as string);
+    const contexts = await parser.parseDirectory(args.path as string, {
+      recursive: !(args["no-recursive"] as boolean),
+    });
 
     const engine = new RulesEngine();
     if (args.rules) {

--- a/oak-terraform-linter/src/core/parser.ts
+++ b/oak-terraform-linter/src/core/parser.ts
@@ -1,7 +1,7 @@
 import { parse } from "@cdktf/hcl2json";
 import * as fs from "fs";
 import * as path from "path";
-import { TerraformFileContext } from "./types";
+import { TerraformFileContext, ParseOptions } from "./types";
 
 export class TerraformParser {
   async parseFile(filePath: string): Promise<TerraformFileContext> {
@@ -48,8 +48,12 @@ export class TerraformParser {
     }
   }
 
-  async parseDirectory(dirPath: string): Promise<TerraformFileContext[]> {
-    const files = this.findTerraformFiles(dirPath);
+  async parseDirectory(
+    dirPath: string,
+    options?: ParseOptions
+  ): Promise<TerraformFileContext[]> {
+    const parseOptions: ParseOptions = options || { recursive: true };
+    const files = this.findTerraformFiles(dirPath, parseOptions);
     const concurrencyLimit = 10;
     const contexts: TerraformFileContext[] = [];
 
@@ -62,14 +66,27 @@ export class TerraformParser {
     return contexts;
   }
 
-  private findTerraformFiles(dirPath: string): string[] {
+  private findTerraformFiles(dirPath: string, options: ParseOptions): string[] {
     const files: string[] = [];
     const entries = fs.readdirSync(dirPath, { withFileTypes: true });
 
     for (const entry of entries) {
       const fullPath = path.join(dirPath, entry.name);
       if (entry.isDirectory()) {
-        files.push(...this.findTerraformFiles(fullPath));
+        // Skip node_modules
+        if (entry.name === "node_modules") {
+          continue;
+        }
+
+        // Skip dot-directories (e.g. '.terraform')
+        if (entry.name.startsWith(".")) {
+          continue;
+        }
+
+        // Only recurse if recursive mode is enabled
+        if (options.recursive) {
+          files.push(...this.findTerraformFiles(fullPath, options));
+        }
       } else if (entry.name.endsWith(".tf")) {
         files.push(fullPath);
       }

--- a/oak-terraform-linter/src/core/parser.ts
+++ b/oak-terraform-linter/src/core/parser.ts
@@ -34,7 +34,10 @@ export class TerraformParser {
    * }
    * ```
    */
-  async parseContent(content: string, filePath: string): Promise<TerraformFileContext> {
+  async parseContent(
+    content: string,
+    filePath: string,
+  ): Promise<TerraformFileContext> {
     try {
       const parsed = await parse(filePath, content);
       return {
@@ -55,7 +58,9 @@ export class TerraformParser {
 
     for (let i = 0; i < files.length; i += concurrencyLimit) {
       const batch = files.slice(i, i + concurrencyLimit);
-      const batchResults = await Promise.all(batch.map((file) => this.parseFile(file)));
+      const batchResults = await Promise.all(
+        batch.map((file) => this.parseFile(file)),
+      );
       contexts.push(...batchResults);
     }
 

--- a/oak-terraform-linter/src/core/parser.ts
+++ b/oak-terraform-linter/src/core/parser.ts
@@ -34,10 +34,7 @@ export class TerraformParser {
    * }
    * ```
    */
-  async parseContent(
-    content: string,
-    filePath: string,
-  ): Promise<TerraformFileContext> {
+  async parseContent(content: string, filePath: string): Promise<TerraformFileContext> {
     try {
       const parsed = await parse(filePath, content);
       return {
@@ -58,9 +55,7 @@ export class TerraformParser {
 
     for (let i = 0; i < files.length; i += concurrencyLimit) {
       const batch = files.slice(i, i + concurrencyLimit);
-      const batchResults = await Promise.all(
-        batch.map((file) => this.parseFile(file)),
-      );
+      const batchResults = await Promise.all(batch.map((file) => this.parseFile(file)));
       contexts.push(...batchResults);
     }
 

--- a/oak-terraform-linter/src/core/parser.ts
+++ b/oak-terraform-linter/src/core/parser.ts
@@ -1,0 +1,80 @@
+import { parse } from "@cdktf/hcl2json";
+import * as fs from "fs";
+import * as path from "path";
+import { TerraformFileContext } from "./types";
+
+export class TerraformParser {
+  async parseFile(filePath: string): Promise<TerraformFileContext> {
+    const fileContent = fs.readFileSync(filePath, "utf-8");
+    return this.parseContent(fileContent, filePath);
+  }
+
+  /**
+   * Parses HCL content into a JavaScript object.
+   * We use @cdktf/hcl2json - see https://www.npmjs.com/package/@cdktf/hcl2json
+   * You can use the parse command in this package to see the exact output structure of the parser.
+   *
+   * Example output structure for the parsed HCL object (note how config blocks are wrapped in arrays):
+   * ```json
+   * {
+   *   "resource": {
+   *     "aws_vpc": {
+   *       "main": [{ "cidr_block": "10.0.0.0/16" }]
+   *     }
+   *   },
+   *   "variable": {
+   *     "name": [
+   *       {
+   *         "description": "Name to be used on all resources",
+   *         "type": "${string}",
+   *         "default": ""
+   *       }
+   *     ]
+   *   }
+   * }
+   * ```
+   */
+  async parseContent(content: string, filePath: string): Promise<TerraformFileContext> {
+    try {
+      const parsed = await parse(filePath, content);
+      return {
+        hcl: parsed,
+        filePath,
+        fileContent: content,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to parse ${filePath}: ${message}`);
+    }
+  }
+
+  async parseDirectory(dirPath: string): Promise<TerraformFileContext[]> {
+    const files = this.findTerraformFiles(dirPath);
+    const concurrencyLimit = 10;
+    const contexts: TerraformFileContext[] = [];
+
+    for (let i = 0; i < files.length; i += concurrencyLimit) {
+      const batch = files.slice(i, i + concurrencyLimit);
+      const batchResults = await Promise.all(batch.map((file) => this.parseFile(file)));
+      contexts.push(...batchResults);
+    }
+
+    return contexts;
+  }
+
+  private findTerraformFiles(dirPath: string): string[] {
+    const files: string[] = [];
+    const entries = fs.readdirSync(dirPath, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const fullPath = path.join(dirPath, entry.name);
+      if (entry.isDirectory()) {
+        files.push(...this.findTerraformFiles(fullPath));
+      } else if (entry.name.endsWith(".tf")) {
+        files.push(fullPath);
+      }
+    }
+
+    return files;
+  }
+}

--- a/oak-terraform-linter/src/core/parser.ts
+++ b/oak-terraform-linter/src/core/parser.ts
@@ -48,10 +48,7 @@ export class TerraformParser {
     }
   }
 
-  async parseDirectory(
-    dirPath: string,
-    options?: ParseOptions
-  ): Promise<TerraformFileContext[]> {
+  async parseDirectory(dirPath: string, options?: ParseOptions): Promise<TerraformFileContext[]> {
     const parseOptions: ParseOptions = options || { recursive: true };
     const files = this.findTerraformFiles(dirPath, parseOptions);
     const concurrencyLimit = 10;

--- a/oak-terraform-linter/src/core/types.ts
+++ b/oak-terraform-linter/src/core/types.ts
@@ -43,6 +43,6 @@ export interface Rule {
   validate(
     context: TerraformFileContext,
     executionContext: ExecutionContext,
-    params?: Record<string, unknown>,
+    params?: Record<string, unknown>
   ): LintViolation[];
 }

--- a/oak-terraform-linter/src/core/types.ts
+++ b/oak-terraform-linter/src/core/types.ts
@@ -43,6 +43,6 @@ export interface Rule {
   validate(
     context: TerraformFileContext,
     executionContext: ExecutionContext,
-    params?: Record<string, unknown>
+    params?: Record<string, unknown>,
   ): LintViolation[];
 }

--- a/oak-terraform-linter/src/core/types.ts
+++ b/oak-terraform-linter/src/core/types.ts
@@ -34,6 +34,10 @@ export interface ExecutionContext {
   isPrivateRepo?: boolean;
 }
 
+export interface ParseOptions {
+  recursive: boolean;
+}
+
 export interface Rule {
   id: string;
   name: string;

--- a/oak-terraform-linter/src/core/types.ts
+++ b/oak-terraform-linter/src/core/types.ts
@@ -1,0 +1,48 @@
+export interface TerraformFileContext {
+  /**
+   * The parsed HCL content as a JavaScript object.
+   * See parser.ts for details on the structure.
+   */
+  hcl: Record<string, unknown>;
+  filePath: string;
+  fileContent: string;
+}
+
+export interface LintViolation {
+  ruleId: string;
+  ruleName: string;
+  severity: "error" | "warning" | "info";
+  filePath: string;
+  message: string;
+  suggestion?: string;
+}
+
+export interface LintResult {
+  violations: LintViolation[];
+  fileCount: number;
+  duration: number;
+  passed: boolean;
+}
+
+export interface RuleConfig {
+  ruleType: string;
+  enabled?: boolean;
+  params?: Record<string, unknown>;
+}
+
+export interface ExecutionContext {
+  isPrivateRepo?: boolean;
+}
+
+export interface Rule {
+  id: string;
+  name: string;
+  description: string;
+  severity: "error" | "warning" | "info";
+  params?: Record<string, unknown>;
+  validate(
+    context: TerraformFileContext,
+    executionContext: ExecutionContext,
+    params?: Record<string, unknown>
+  ): LintViolation[];
+}

--- a/oak-terraform-linter/src/index.ts
+++ b/oak-terraform-linter/src/index.ts
@@ -1,0 +1,6 @@
+import { runCLI } from "./cli";
+
+(async () => {
+  const exitCode = await runCLI(process.argv.slice(2));
+  process.exit(exitCode);
+})();

--- a/oak-terraform-linter/src/reporters/human.ts
+++ b/oak-terraform-linter/src/reporters/human.ts
@@ -1,0 +1,76 @@
+import { LintViolation } from "../core/types";
+import chalk from "chalk";
+
+export class HumanReporter {
+  report(violations: LintViolation[], _options: { strict: boolean; fileCount: number }): void {
+    if (violations.length === 0) {
+      console.log(chalk.green("✓ No violations found!"));
+      return;
+    }
+
+    const byFile = this.groupByFile(violations);
+
+    for (const [file, fileViolations] of Object.entries(byFile)) {
+      console.log(chalk.underline(file));
+
+      for (const violation of fileViolations) {
+        const icon = this.getIcon(violation.severity);
+        const colorFn = this.getColorFn(violation.severity);
+
+        console.log(`  ${icon}  ${colorFn(violation.message)} (${violation.ruleId})`);
+
+        if (violation.suggestion) {
+          console.log(chalk.gray(`     💡 ${violation.suggestion}`));
+        }
+      }
+      console.log();
+    }
+
+    const errors = violations.filter((v) => v.severity === "error").length;
+    const warnings = violations.filter((v) => v.severity === "warning").length;
+
+    console.log(
+      `Found ${chalk.red(`${errors} error`)}${errors !== 1 ? "s" : ""}, ${chalk.yellow(
+        `${warnings} warning`
+      )}${warnings !== 1 ? "s" : ""}`
+    );
+  }
+
+  private groupByFile(violations: LintViolation[]): Record<string, LintViolation[]> {
+    const result: Record<string, LintViolation[]> = {};
+    for (const violation of violations) {
+      const file = violation.filePath;
+      if (!result[file]) {
+        result[file] = [];
+      }
+      result[file].push(violation);
+    }
+    return result;
+  }
+
+  private getIcon(severity: string): string {
+    switch (severity) {
+      case "error":
+        return "✘";
+      case "warning":
+        return "⚠";
+      case "info":
+        return "ℹ";
+      default:
+        return "•";
+    }
+  }
+
+  private getColorFn(severity: string): (text: string) => string {
+    switch (severity) {
+      case "error":
+        return chalk.red;
+      case "warning":
+        return chalk.yellow;
+      case "info":
+        return chalk.cyan;
+      default:
+        return chalk.white;
+    }
+  }
+}

--- a/oak-terraform-linter/src/reporters/human.ts
+++ b/oak-terraform-linter/src/reporters/human.ts
@@ -2,7 +2,10 @@ import { LintViolation } from "../core/types";
 import chalk from "chalk";
 
 export class HumanReporter {
-  report(violations: LintViolation[], _options: { strict: boolean; fileCount: number }): void {
+  report(
+    violations: LintViolation[],
+    _options: { strict: boolean; fileCount: number },
+  ): void {
     if (violations.length === 0) {
       console.log(chalk.green("✓ No violations found!"));
       return;
@@ -17,7 +20,9 @@ export class HumanReporter {
         const icon = this.getIcon(violation.severity);
         const colorFn = this.getColorFn(violation.severity);
 
-        console.log(`  ${icon}  ${colorFn(violation.message)} (${violation.ruleId})`);
+        console.log(
+          `  ${icon}  ${colorFn(violation.message)} (${violation.ruleId})`,
+        );
 
         if (violation.suggestion) {
           console.log(chalk.gray(`     💡 ${violation.suggestion}`));
@@ -31,12 +36,14 @@ export class HumanReporter {
 
     console.log(
       `Found ${chalk.red(`${errors} error`)}${errors !== 1 ? "s" : ""}, ${chalk.yellow(
-        `${warnings} warning`
-      )}${warnings !== 1 ? "s" : ""}`
+        `${warnings} warning`,
+      )}${warnings !== 1 ? "s" : ""}`,
     );
   }
 
-  private groupByFile(violations: LintViolation[]): Record<string, LintViolation[]> {
+  private groupByFile(
+    violations: LintViolation[],
+  ): Record<string, LintViolation[]> {
     const result: Record<string, LintViolation[]> = {};
     for (const violation of violations) {
       const file = violation.filePath;

--- a/oak-terraform-linter/src/reporters/human.ts
+++ b/oak-terraform-linter/src/reporters/human.ts
@@ -2,10 +2,7 @@ import { LintViolation } from "../core/types";
 import chalk from "chalk";
 
 export class HumanReporter {
-  report(
-    violations: LintViolation[],
-    _options: { strict: boolean; fileCount: number },
-  ): void {
+  report(violations: LintViolation[], _options: { strict: boolean; fileCount: number }): void {
     if (violations.length === 0) {
       console.log(chalk.green("✓ No violations found!"));
       return;
@@ -20,9 +17,7 @@ export class HumanReporter {
         const icon = this.getIcon(violation.severity);
         const colorFn = this.getColorFn(violation.severity);
 
-        console.log(
-          `  ${icon}  ${colorFn(violation.message)} (${violation.ruleId})`,
-        );
+        console.log(`  ${icon}  ${colorFn(violation.message)} (${violation.ruleId})`);
 
         if (violation.suggestion) {
           console.log(chalk.gray(`     💡 ${violation.suggestion}`));
@@ -36,14 +31,12 @@ export class HumanReporter {
 
     console.log(
       `Found ${chalk.red(`${errors} error`)}${errors !== 1 ? "s" : ""}, ${chalk.yellow(
-        `${warnings} warning`,
-      )}${warnings !== 1 ? "s" : ""}`,
+        `${warnings} warning`
+      )}${warnings !== 1 ? "s" : ""}`
     );
   }
 
-  private groupByFile(
-    violations: LintViolation[],
-  ): Record<string, LintViolation[]> {
+  private groupByFile(violations: LintViolation[]): Record<string, LintViolation[]> {
     const result: Record<string, LintViolation[]> = {};
     for (const violation of violations) {
       const file = violation.filePath;

--- a/oak-terraform-linter/src/rules/RULE_AUTHORING.md
+++ b/oak-terraform-linter/src/rules/RULE_AUTHORING.md
@@ -1,0 +1,118 @@
+# Rule Authoring Guide
+
+## Overview
+
+Rules are TypeScript classes that implement the `Rule` interface. They validate Terraform configurations against specific requirements.
+
+## Rule Interface
+
+```typescript
+interface Rule {
+  id: string;
+  name: string;
+  description: string;
+  severity: "error" | "warning" | "info";
+  params?: Record<string, unknown>;
+  validate(
+    context: TerraformFileContext,
+    executionContext: ExecutionContext,
+    params?: Record<string, unknown>
+  ): LintViolation[];
+}
+```
+
+## Creating a Custom Rule
+
+### Step 1: Create the Rule Class
+
+The Rule Engine will loop through all `.tf` files found in the linter's target path and call your rule's `validate` function on each one.
+
+```typescript
+import { Rule, TerraformFileContext, ExecutionContext, LintViolation } from "../core/types";
+
+export class MyCustomRule implements Rule {
+  id = "custom-my-rule-001";
+  name = "My Custom Rule";
+  description = "Description of what this rule checks";
+  severity = "error" as const;
+  params: Record<string, unknown> = {};
+
+  validate(
+    context: TerraformFileContext,
+    executionContext: ExecutionContext,
+    params?: Record<string, unknown>
+  ): LintViolation[] {
+    const violations: LintViolation[] = [];
+
+    // Your validation logic here.
+
+    // You can examine:
+    // - context: Information about a specific .tf file including parsed HCL.
+    // - executionContext: If this is running in a private repo etc. Please extend this as needed.
+    // to generate violations.
+
+    // Check parser.ts for an example of the structure of the parsed HCL JSON so you know how to manipulate it.
+    // You can also use 'npm run parse' to output parsed HCL JSON of any terraform file.
+    // See src/commands/parse/README.md for details.
+
+    return violations;
+  }
+}
+```
+
+### Step 2: Register the Rule
+
+Add your rule to `src/rules` and update `AVAILABLE_RULES` in `src/rules/loader.ts`:
+
+```typescript
+import { MyCustomRule } from "./my-custom";
+
+const AVAILABLE_RULES: Record<string, new () => Rule> = {
+  "naming-convention": NamingConventionRule,
+  "my-custom": MyCustomRule,
+};
+```
+
+### Step 3: Decide if it should be added to the Default configuration
+
+Update `DEFAULT_RULES` in `src/rules/loader.ts`:
+
+```typescript
+const DEFAULT_RULES: RuleConfig[] = [
+  {
+    ruleType: "my-custom",
+    enabled: true, // optional, true if omitted
+    params: {
+      // optional
+      option1: "value1",
+    },
+  },
+];
+```
+
+### Step 4: Add the Rule to an external config
+
+If added to `DEFAULT_RULES` your new rule will be run if no config file is passed. However if a configuration file (json) is passed to the linter you will need to make sure your new rule is included:
+
+```json
+{
+  "rules": [
+    {
+      "ruleType": "my-custom",
+      "enabled": true,
+      "params": {
+        "option1": "value1"
+      }
+    }
+  ]
+}
+```
+
+## Best Practices
+
+1. **Clear IDs**: Use format `{organization}-{rule-name}-{version}` (e.g., `oak-naming-001`)
+1. **Clear Filenames** Use format `rule-{rule-name}.ts`
+1. **Helpful Messages**: Violation messages should clearly explain what's wrong
+1. **Suggestions**: Provide actionable suggestions when possible
+1. **Error Handling**: Gracefully handle unexpected JSON structures from the parser
+1. **Documentation**: Add descriptions explaining the rule's purpose

--- a/oak-terraform-linter/src/rules/RULE_AUTHORING.md
+++ b/oak-terraform-linter/src/rules/RULE_AUTHORING.md
@@ -16,7 +16,7 @@ interface Rule {
   validate(
     context: TerraformFileContext,
     executionContext: ExecutionContext,
-    params?: Record<string, unknown>
+    params?: Record<string, unknown>,
   ): LintViolation[];
 }
 ```
@@ -28,7 +28,12 @@ interface Rule {
 The Rule Engine will loop through all `.tf` files found in the linter's target path and call your rule's `validate` function on each one.
 
 ```typescript
-import { Rule, TerraformFileContext, ExecutionContext, LintViolation } from "../core/types";
+import {
+  Rule,
+  TerraformFileContext,
+  ExecutionContext,
+  LintViolation,
+} from "../core/types";
 
 export class MyCustomRule implements Rule {
   id = "custom-my-rule-001";
@@ -40,7 +45,7 @@ export class MyCustomRule implements Rule {
   validate(
     context: TerraformFileContext,
     executionContext: ExecutionContext,
-    params?: Record<string, unknown>
+    params?: Record<string, unknown>,
   ): LintViolation[] {
     const violations: LintViolation[] = [];
 

--- a/oak-terraform-linter/src/rules/RULE_AUTHORING.md
+++ b/oak-terraform-linter/src/rules/RULE_AUTHORING.md
@@ -16,7 +16,7 @@ interface Rule {
   validate(
     context: TerraformFileContext,
     executionContext: ExecutionContext,
-    params?: Record<string, unknown>,
+    params?: Record<string, unknown>
   ): LintViolation[];
 }
 ```
@@ -28,12 +28,7 @@ interface Rule {
 The Rule Engine will loop through all `.tf` files found in the linter's target path and call your rule's `validate` function on each one.
 
 ```typescript
-import {
-  Rule,
-  TerraformFileContext,
-  ExecutionContext,
-  LintViolation,
-} from "../core/types";
+import { Rule, TerraformFileContext, ExecutionContext, LintViolation } from "../core/types";
 
 export class MyCustomRule implements Rule {
   id = "custom-my-rule-001";
@@ -45,7 +40,7 @@ export class MyCustomRule implements Rule {
   validate(
     context: TerraformFileContext,
     executionContext: ExecutionContext,
-    params?: Record<string, unknown>,
+    params?: Record<string, unknown>
   ): LintViolation[] {
     const violations: LintViolation[] = [];
 

--- a/oak-terraform-linter/src/rules/engine.ts
+++ b/oak-terraform-linter/src/rules/engine.ts
@@ -1,0 +1,38 @@
+import { TerraformFileContext, ExecutionContext, LintViolation, Rule } from "../core/types";
+import { RuleLoader } from "./loader";
+
+export class RulesEngine {
+  private rules: Rule[] = [];
+  private loader: RuleLoader;
+
+  constructor() {
+    this.loader = new RuleLoader();
+  }
+
+  async loadRules(filePath: string): Promise<void> {
+    this.rules = await this.loader.loadRulesFromFile(filePath);
+  }
+
+  loadDefaultRules(): void {
+    this.rules = this.loader.loadDefaultRules();
+  }
+
+  executeRules(context: TerraformFileContext, executionContext: ExecutionContext): LintViolation[] {
+    const violations: LintViolation[] = [];
+
+    for (const rule of this.rules) {
+      const ruleViolations = rule.validate(context, executionContext, rule.params);
+      violations.push(...ruleViolations);
+    }
+
+    return violations;
+  }
+
+  registerRule(rule: Rule): void {
+    this.rules.push(rule);
+  }
+
+  getRules(): Rule[] {
+    return this.rules;
+  }
+}

--- a/oak-terraform-linter/src/rules/engine.ts
+++ b/oak-terraform-linter/src/rules/engine.ts
@@ -1,9 +1,4 @@
-import {
-  TerraformFileContext,
-  ExecutionContext,
-  LintViolation,
-  Rule,
-} from "../core/types";
+import { TerraformFileContext, ExecutionContext, LintViolation, Rule } from "../core/types";
 import { RuleLoader } from "./loader";
 
 export class RulesEngine {
@@ -22,18 +17,11 @@ export class RulesEngine {
     this.rules = this.loader.loadDefaultRules();
   }
 
-  executeRules(
-    context: TerraformFileContext,
-    executionContext: ExecutionContext,
-  ): LintViolation[] {
+  executeRules(context: TerraformFileContext, executionContext: ExecutionContext): LintViolation[] {
     const violations: LintViolation[] = [];
 
     for (const rule of this.rules) {
-      const ruleViolations = rule.validate(
-        context,
-        executionContext,
-        rule.params,
-      );
+      const ruleViolations = rule.validate(context, executionContext, rule.params);
       violations.push(...ruleViolations);
     }
 

--- a/oak-terraform-linter/src/rules/engine.ts
+++ b/oak-terraform-linter/src/rules/engine.ts
@@ -1,4 +1,9 @@
-import { TerraformFileContext, ExecutionContext, LintViolation, Rule } from "../core/types";
+import {
+  TerraformFileContext,
+  ExecutionContext,
+  LintViolation,
+  Rule,
+} from "../core/types";
 import { RuleLoader } from "./loader";
 
 export class RulesEngine {
@@ -17,11 +22,18 @@ export class RulesEngine {
     this.rules = this.loader.loadDefaultRules();
   }
 
-  executeRules(context: TerraformFileContext, executionContext: ExecutionContext): LintViolation[] {
+  executeRules(
+    context: TerraformFileContext,
+    executionContext: ExecutionContext,
+  ): LintViolation[] {
     const violations: LintViolation[] = [];
 
     for (const rule of this.rules) {
-      const ruleViolations = rule.validate(context, executionContext, rule.params);
+      const ruleViolations = rule.validate(
+        context,
+        executionContext,
+        rule.params,
+      );
       violations.push(...ruleViolations);
     }
 

--- a/oak-terraform-linter/src/rules/loader.ts
+++ b/oak-terraform-linter/src/rules/loader.ts
@@ -1,11 +1,7 @@
 import * as fs from "fs";
 import { Rule, RuleConfig } from "../core/types";
 import { ResourceNamingRule } from "./rule-resource-naming";
-import {
-  HelperPassingRule,
-  HelperFailingRule,
-  HelperErrorRule,
-} from "./rule-helpers";
+import { HelperPassingRule, HelperFailingRule, HelperErrorRule } from "./rule-helpers";
 
 const AVAILABLE_RULES: Record<string, new () => Rule> = {
   "helper-always-passes": HelperPassingRule,
@@ -45,8 +41,8 @@ export class RuleLoader {
         if (!ruleClass) {
           throw new Error(
             `Rule type '${config.ruleType}' not found. Available types: ${Object.keys(
-              AVAILABLE_RULES,
-            ).join(", ")}`,
+              AVAILABLE_RULES
+            ).join(", ")}`
           );
         }
 
@@ -59,9 +55,7 @@ export class RuleLoader {
         rules.push(rule);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        throw new Error(
-          `Failed to instantiate rule '${config.ruleType}': ${message}`,
-        );
+        throw new Error(`Failed to instantiate rule '${config.ruleType}': ${message}`);
       }
     }
 

--- a/oak-terraform-linter/src/rules/loader.ts
+++ b/oak-terraform-linter/src/rules/loader.ts
@@ -1,0 +1,64 @@
+import * as fs from "fs";
+import { Rule, RuleConfig } from "../core/types";
+import { ResourceNamingRule } from "./rule-resource-naming";
+import { HelperPassingRule, HelperFailingRule, HelperErrorRule } from "./rule-helpers";
+
+const AVAILABLE_RULES: Record<string, new () => Rule> = {
+  "helper-always-passes": HelperPassingRule,
+  "helper-always-fails": HelperFailingRule,
+  "helper-always-errors": HelperErrorRule,
+  "resource-naming": ResourceNamingRule,
+};
+
+const DEFAULT_RULES: RuleConfig[] = [{ ruleType: "resource-naming" }];
+
+export class RuleLoader {
+  async loadRulesFromFile(filePath: string): Promise<Rule[]> {
+    try {
+      const content = fs.readFileSync(filePath, "utf-8");
+      const config = JSON.parse(content) as { rules: RuleConfig[] };
+      return this.instantiateRules(config.rules);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to load rules from ${filePath}: ${message}`);
+    }
+  }
+
+  loadDefaultRules(): Rule[] {
+    return this.instantiateRules(DEFAULT_RULES);
+  }
+
+  private instantiateRules(configs: RuleConfig[]): Rule[] {
+    const rules: Rule[] = [];
+
+    for (const config of configs) {
+      if (config.enabled === false) {
+        continue;
+      }
+
+      try {
+        const ruleClass = AVAILABLE_RULES[config.ruleType];
+        if (!ruleClass) {
+          throw new Error(
+            `Rule type '${config.ruleType}' not found. Available types: ${Object.keys(
+              AVAILABLE_RULES
+            ).join(", ")}`
+          );
+        }
+
+        const rule = new ruleClass();
+
+        if (config.params) {
+          rule.params = { ...rule.params, ...config.params };
+        }
+
+        rules.push(rule);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`Failed to instantiate rule '${config.ruleType}': ${message}`);
+      }
+    }
+
+    return rules;
+  }
+}

--- a/oak-terraform-linter/src/rules/loader.ts
+++ b/oak-terraform-linter/src/rules/loader.ts
@@ -1,7 +1,11 @@
 import * as fs from "fs";
 import { Rule, RuleConfig } from "../core/types";
 import { ResourceNamingRule } from "./rule-resource-naming";
-import { HelperPassingRule, HelperFailingRule, HelperErrorRule } from "./rule-helpers";
+import {
+  HelperPassingRule,
+  HelperFailingRule,
+  HelperErrorRule,
+} from "./rule-helpers";
 
 const AVAILABLE_RULES: Record<string, new () => Rule> = {
   "helper-always-passes": HelperPassingRule,
@@ -41,8 +45,8 @@ export class RuleLoader {
         if (!ruleClass) {
           throw new Error(
             `Rule type '${config.ruleType}' not found. Available types: ${Object.keys(
-              AVAILABLE_RULES
-            ).join(", ")}`
+              AVAILABLE_RULES,
+            ).join(", ")}`,
           );
         }
 
@@ -55,7 +59,9 @@ export class RuleLoader {
         rules.push(rule);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        throw new Error(`Failed to instantiate rule '${config.ruleType}': ${message}`);
+        throw new Error(
+          `Failed to instantiate rule '${config.ruleType}': ${message}`,
+        );
       }
     }
 

--- a/oak-terraform-linter/src/rules/rule-helpers.ts
+++ b/oak-terraform-linter/src/rules/rule-helpers.ts
@@ -1,4 +1,9 @@
-import { Rule, TerraformFileContext, ExecutionContext, LintViolation } from "../core/types";
+import {
+  Rule,
+  TerraformFileContext,
+  ExecutionContext,
+  LintViolation,
+} from "../core/types";
 
 export class HelperPassingRule implements Rule {
   id = "oak-helper-pass-001";
@@ -10,7 +15,7 @@ export class HelperPassingRule implements Rule {
   validate(
     _context: TerraformFileContext,
     _executionContext: ExecutionContext,
-    _params?: Record<string, unknown>
+    _params?: Record<string, unknown>,
   ): LintViolation[] {
     return [];
   }
@@ -26,7 +31,7 @@ export class HelperFailingRule implements Rule {
   validate(
     _context: TerraformFileContext,
     _executionContext: ExecutionContext,
-    _params?: Record<string, unknown>
+    _params?: Record<string, unknown>,
   ): LintViolation[] {
     return [
       {
@@ -51,7 +56,7 @@ export class HelperErrorRule implements Rule {
   validate(
     _context: TerraformFileContext,
     _executionContext: ExecutionContext,
-    _params?: Record<string, unknown>
+    _params?: Record<string, unknown>,
   ): LintViolation[] {
     throw new Error("This rule always errors (for development purposes only)");
   }

--- a/oak-terraform-linter/src/rules/rule-helpers.ts
+++ b/oak-terraform-linter/src/rules/rule-helpers.ts
@@ -1,0 +1,58 @@
+import { Rule, TerraformFileContext, ExecutionContext, LintViolation } from "../core/types";
+
+export class HelperPassingRule implements Rule {
+  id = "oak-helper-pass-001";
+  name = "Helper Passing Rule (Dev Only)";
+  description = "This rule always passes (for development purposes only)";
+  severity = "error" as const;
+  params: Record<string, unknown> = {};
+
+  validate(
+    _context: TerraformFileContext,
+    _executionContext: ExecutionContext,
+    _params?: Record<string, unknown>
+  ): LintViolation[] {
+    return [];
+  }
+}
+
+export class HelperFailingRule implements Rule {
+  id = "oak-helper-fail-001";
+  name = "Helper Failing Rule (Dev Only)";
+  description = "This rule always fails (for development purposes only)";
+  severity = "error" as const;
+  params: Record<string, unknown> = {};
+
+  validate(
+    _context: TerraformFileContext,
+    _executionContext: ExecutionContext,
+    _params?: Record<string, unknown>
+  ): LintViolation[] {
+    return [
+      {
+        ruleName: this.name,
+        ruleId: this.id,
+        severity: this.severity,
+        filePath: _context.filePath,
+        message: "This rule always fails (for development purposes only)",
+        suggestion: "Remove this rule from your configuration",
+      },
+    ];
+  }
+}
+
+export class HelperErrorRule implements Rule {
+  id = "oak-helper-error-001";
+  name = "Helper Error Rule (Dev Only)";
+  description = "This rule always errors (for development purposes only)";
+  severity = "error" as const;
+  params: Record<string, unknown> = {};
+
+  validate(
+    _context: TerraformFileContext,
+    _executionContext: ExecutionContext,
+    _params?: Record<string, unknown>
+  ): LintViolation[] {
+    throw new Error("This rule always errors (for development purposes only)");
+  }
+}

--- a/oak-terraform-linter/src/rules/rule-helpers.ts
+++ b/oak-terraform-linter/src/rules/rule-helpers.ts
@@ -1,9 +1,4 @@
-import {
-  Rule,
-  TerraformFileContext,
-  ExecutionContext,
-  LintViolation,
-} from "../core/types";
+import { Rule, TerraformFileContext, ExecutionContext, LintViolation } from "../core/types";
 
 export class HelperPassingRule implements Rule {
   id = "oak-helper-pass-001";
@@ -15,7 +10,7 @@ export class HelperPassingRule implements Rule {
   validate(
     _context: TerraformFileContext,
     _executionContext: ExecutionContext,
-    _params?: Record<string, unknown>,
+    _params?: Record<string, unknown>
   ): LintViolation[] {
     return [];
   }
@@ -31,7 +26,7 @@ export class HelperFailingRule implements Rule {
   validate(
     _context: TerraformFileContext,
     _executionContext: ExecutionContext,
-    _params?: Record<string, unknown>,
+    _params?: Record<string, unknown>
   ): LintViolation[] {
     return [
       {
@@ -56,7 +51,7 @@ export class HelperErrorRule implements Rule {
   validate(
     _context: TerraformFileContext,
     _executionContext: ExecutionContext,
-    _params?: Record<string, unknown>,
+    _params?: Record<string, unknown>
   ): LintViolation[] {
     throw new Error("This rule always errors (for development purposes only)");
   }

--- a/oak-terraform-linter/src/rules/rule-resource-naming.ts
+++ b/oak-terraform-linter/src/rules/rule-resource-naming.ts
@@ -45,7 +45,7 @@ export class ResourceNamingRule implements Rule {
               : `Resource name '${resourceName}' does not match naming convention '${pattern}'.`,
             suggestion: isSnakeCase
               ? `Rename to match pattern: ${resourceName.toLowerCase().replace(/[^a-z0-9_]/g, "_")}`
-              : "",
+              : undefined,
           });
         }
       }

--- a/oak-terraform-linter/src/rules/rule-resource-naming.ts
+++ b/oak-terraform-linter/src/rules/rule-resource-naming.ts
@@ -1,9 +1,4 @@
-import {
-  Rule,
-  TerraformFileContext,
-  ExecutionContext,
-  LintViolation,
-} from "../core/types";
+import { Rule, TerraformFileContext, ExecutionContext, LintViolation } from "../core/types";
 
 export class ResourceNamingRule implements Rule {
   id = "oak-resource-naming-001";
@@ -15,15 +10,13 @@ export class ResourceNamingRule implements Rule {
   validate(
     context: TerraformFileContext,
     _executionContext: ExecutionContext,
-    params?: Record<string, unknown>,
+    params?: Record<string, unknown>
   ): LintViolation[] {
     const violations: LintViolation[] = [];
     const snakeCasePattern = /^[a-z0-9_]+$/;
     const patternParam = params?.pattern || snakeCasePattern;
     const pattern =
-      typeof patternParam === "string"
-        ? new RegExp(patternParam)
-        : (patternParam as RegExp);
+      typeof patternParam === "string" ? new RegExp(patternParam) : (patternParam as RegExp);
     const isSnakeCase = snakeCasePattern === pattern;
 
     const resources = context.hcl.resource;
@@ -36,14 +29,8 @@ export class ResourceNamingRule implements Rule {
         continue;
       }
 
-      for (const [resourceName, resourceConfig] of Object.entries(
-        resourceInstances,
-      )) {
-        if (
-          !resourceName ||
-          !resourceConfig ||
-          typeof resourceConfig !== "object"
-        ) {
+      for (const [resourceName, resourceConfig] of Object.entries(resourceInstances)) {
+        if (!resourceName || !resourceConfig || typeof resourceConfig !== "object") {
           continue;
         }
 

--- a/oak-terraform-linter/src/rules/rule-resource-naming.ts
+++ b/oak-terraform-linter/src/rules/rule-resource-naming.ts
@@ -1,4 +1,9 @@
-import { Rule, TerraformFileContext, ExecutionContext, LintViolation } from "../core/types";
+import {
+  Rule,
+  TerraformFileContext,
+  ExecutionContext,
+  LintViolation,
+} from "../core/types";
 
 export class ResourceNamingRule implements Rule {
   id = "oak-resource-naming-001";
@@ -10,13 +15,15 @@ export class ResourceNamingRule implements Rule {
   validate(
     context: TerraformFileContext,
     _executionContext: ExecutionContext,
-    params?: Record<string, unknown>
+    params?: Record<string, unknown>,
   ): LintViolation[] {
     const violations: LintViolation[] = [];
     const snakeCasePattern = /^[a-z0-9_]+$/;
     const patternParam = params?.pattern || snakeCasePattern;
     const pattern =
-      typeof patternParam === "string" ? new RegExp(patternParam) : (patternParam as RegExp);
+      typeof patternParam === "string"
+        ? new RegExp(patternParam)
+        : (patternParam as RegExp);
     const isSnakeCase = snakeCasePattern === pattern;
 
     const resources = context.hcl.resource;
@@ -29,8 +36,14 @@ export class ResourceNamingRule implements Rule {
         continue;
       }
 
-      for (const [resourceName, resourceConfig] of Object.entries(resourceInstances)) {
-        if (!resourceName || !resourceConfig || typeof resourceConfig !== "object") {
+      for (const [resourceName, resourceConfig] of Object.entries(
+        resourceInstances,
+      )) {
+        if (
+          !resourceName ||
+          !resourceConfig ||
+          typeof resourceConfig !== "object"
+        ) {
           continue;
         }
 

--- a/oak-terraform-linter/src/rules/rule-resource-naming.ts
+++ b/oak-terraform-linter/src/rules/rule-resource-naming.ts
@@ -1,0 +1,56 @@
+import { Rule, TerraformFileContext, ExecutionContext, LintViolation } from "../core/types";
+
+export class ResourceNamingRule implements Rule {
+  id = "oak-resource-naming-001";
+  name = "Resource Naming Convention";
+  description = "Enforce naming for all resources";
+  severity = "error" as const;
+  params: Record<string, unknown> = {};
+
+  validate(
+    context: TerraformFileContext,
+    _executionContext: ExecutionContext,
+    params?: Record<string, unknown>
+  ): LintViolation[] {
+    const violations: LintViolation[] = [];
+    const snakeCasePattern = /^[a-z0-9_]+$/;
+    const patternParam = params?.pattern || snakeCasePattern;
+    const pattern =
+      typeof patternParam === "string" ? new RegExp(patternParam) : (patternParam as RegExp);
+    const isSnakeCase = snakeCasePattern === pattern;
+
+    const resources = context.hcl.resource;
+    if (!resources || typeof resources !== "object") {
+      return violations;
+    }
+
+    for (const [, resourceInstances] of Object.entries(resources)) {
+      if (!resourceInstances || typeof resourceInstances !== "object") {
+        continue;
+      }
+
+      for (const [resourceName, resourceConfig] of Object.entries(resourceInstances)) {
+        if (!resourceName || !resourceConfig || typeof resourceConfig !== "object") {
+          continue;
+        }
+
+        if (!pattern.test(resourceName)) {
+          violations.push({
+            ruleId: this.id,
+            ruleName: this.name,
+            severity: this.severity,
+            filePath: context.filePath,
+            message: isSnakeCase
+              ? `Resource name '${resourceName}' does not match naming convention 'snake_case'.`
+              : `Resource name '${resourceName}' does not match naming convention '${pattern}'.`,
+            suggestion: isSnakeCase
+              ? `Rename to match pattern: ${resourceName.toLowerCase().replace(/[^a-z0-9_]/g, "_")}`
+              : "",
+          });
+        }
+      }
+    }
+
+    return violations;
+  }
+}


### PR DESCRIPTION
## Description

- This PR contains the core logic of the linter.
- The linter is built around four components:
  - **Parser** (`src/core/parser.ts`) - Converts HCL to JSON using @cdktf/hcl2json
  - **Rules Engine** (`src/rules/engine.ts`) - Loads and executes rules against the parsed HCL
  - **Rule Loader** (`src/rules/loader.ts`) - Instantiates rules (optionally from configuration files)
  - **Reporters** (`src/reporters/`) - Formats and outputs results

## About the linter

- These PRs add the typescript package `oak-terraform-linter`. It is an extensible linter that searches for `.tf` files in a path and validates them against a list of rules.
- The intention is for this to eventally be run as a continuous integration step in github actions for all Oak repositories that contain `terraform` configurations.
- These PRs contains only the linter and an example rule. They do not contain any of the rules we wish to apply to the Oak organisation, or any CI configuration to do so. These are planned as further pieces of work (see the Epic for this task in Notion)
- An overview of the architecture and root of the (hopefully succinct) documentation can be found in the [README](https://github.com/oaknational/oak-terraform-actions/blob/65077c86ca08a4c3173e10c8ac50ade86a960bd8/oak-terraform-linter/README.md) at the root of the package.
- Disclosure: In the spirit of the AI surveys that have recently gone out I experimented with the agent workflow described [here](https://boristane.com/blog/how-i-use-claude-code/) to develop this feature.

## Issue(s)

[ENG-1498](https://www.notion.so/Write-a-custom-Terraform-linter-32126cc4e1b18059bf5feaf3d2c0c466)

## How to test

1. See the [README](https://github.com/oaknational/oak-terraform-actions/blob/fe833b60031c21df535d859679f557061d5bc1a8/oak-terraform-linter/examples/README.md) in the examples folder.