### PR TITLE
feat: Terraform Linter Part 3 - Tests [ENG-1498]

### DIFF
--- a/oak-terraform-linter/tests/integration/configs/naming-relaxed.json
+++ b/oak-terraform-linter/tests/integration/configs/naming-relaxed.json
@@ -1,0 +1,8 @@
+{
+  "rules": [
+    {
+      "ruleType": "resource-naming",
+      "enabled": false
+    }
+  ]
+}

--- a/oak-terraform-linter/tests/integration/configs/naming-strict.json
+++ b/oak-terraform-linter/tests/integration/configs/naming-strict.json
@@ -1,0 +1,11 @@
+{
+  "rules": [
+    {
+      "ruleType": "resource-naming",
+      "enabled": true,
+      "params": {
+        "pattern": "^[a-z0-9_]+$"
+      }
+    }
+  ]
+}

--- a/oak-terraform-linter/tests/integration/end-to-end.test.ts
+++ b/oak-terraform-linter/tests/integration/end-to-end.test.ts
@@ -8,64 +8,93 @@ describe("End-to-End Linting", () => {
   const parser = new TerraformParser();
 
   test("detects naming violations in fixture directory", async () => {
-    const fixtureDir = path.join(__dirname, "../integration/fixtures/naming-violations");
+    const fixtureDir = path.join(
+      __dirname,
+      "../integration/fixtures/naming-violations",
+    );
     const contexts = await parser.parseDirectory(fixtureDir);
 
     const engine = new RulesEngine();
     engine.registerRule(new ResourceNamingRule());
 
     const executionContext: ExecutionContext = { isPrivateRepo: false };
-    const allViolations = contexts.flatMap((ctx) => engine.executeRules(ctx, executionContext));
+    const allViolations = contexts.flatMap((ctx) =>
+      engine.executeRules(ctx, executionContext),
+    );
 
     expect(allViolations.length).toBeGreaterThan(0);
     expect(allViolations[0].ruleId).toBe("oak-resource-naming-001");
   });
 
   test("passes clean Terraform files", async () => {
-    const fixtureDir = path.join(__dirname, "../integration/fixtures/valid-terraform");
+    const fixtureDir = path.join(
+      __dirname,
+      "../integration/fixtures/valid-terraform",
+    );
     const contexts = await parser.parseDirectory(fixtureDir);
 
     const engine = new RulesEngine();
     engine.registerRule(new ResourceNamingRule());
 
     const executionContext: ExecutionContext = { isPrivateRepo: false };
-    const allViolations = contexts.flatMap((ctx) => engine.executeRules(ctx, executionContext));
+    const allViolations = contexts.flatMap((ctx) =>
+      engine.executeRules(ctx, executionContext),
+    );
 
     expect(allViolations).toHaveLength(0);
   });
 
   test("processes multiple files", async () => {
-    const fixtureDir = path.join(__dirname, "../integration/fixtures/valid-terraform");
+    const fixtureDir = path.join(
+      __dirname,
+      "../integration/fixtures/valid-terraform",
+    );
     const contexts = await parser.parseDirectory(fixtureDir);
 
     expect(contexts.length).toBeGreaterThan(1);
   });
 
   test("loads and applies rules from strict config", async () => {
-    const fixtureDir = path.join(__dirname, "../integration/fixtures/naming-violations");
-    const configPath = path.join(__dirname, "../integration/configs/naming-strict.json");
+    const fixtureDir = path.join(
+      __dirname,
+      "../integration/fixtures/naming-violations",
+    );
+    const configPath = path.join(
+      __dirname,
+      "../integration/configs/naming-strict.json",
+    );
     const contexts = await parser.parseDirectory(fixtureDir);
 
     const engine = new RulesEngine();
     await engine.loadRules(configPath);
 
     const executionContext: ExecutionContext = { isPrivateRepo: false };
-    const allViolations = contexts.flatMap((ctx) => engine.executeRules(ctx, executionContext));
+    const allViolations = contexts.flatMap((ctx) =>
+      engine.executeRules(ctx, executionContext),
+    );
 
     expect(allViolations.length).toBeGreaterThan(0);
     expect(allViolations[0].ruleId).toBe("oak-resource-naming-001");
   });
 
   test("loads and respects disabled rules from config", async () => {
-    const fixtureDir = path.join(__dirname, "../integration/fixtures/naming-violations");
-    const configPath = path.join(__dirname, "../integration/configs/naming-relaxed.json");
+    const fixtureDir = path.join(
+      __dirname,
+      "../integration/fixtures/naming-violations",
+    );
+    const configPath = path.join(
+      __dirname,
+      "../integration/configs/naming-relaxed.json",
+    );
     const contexts = await parser.parseDirectory(fixtureDir);
 
     const engine = new RulesEngine();
     await engine.loadRules(configPath);
 
     const executionContext: ExecutionContext = { isPrivateRepo: false };
-    const allViolations = contexts.flatMap((ctx) => engine.executeRules(ctx, executionContext));
+    const allViolations = contexts.flatMap((ctx) =>
+      engine.executeRules(ctx, executionContext),
+    );
 
     // No violations because the naming rule is disabled in the config
     expect(allViolations).toHaveLength(0);

--- a/oak-terraform-linter/tests/integration/end-to-end.test.ts
+++ b/oak-terraform-linter/tests/integration/end-to-end.test.ts
@@ -19,6 +19,16 @@ describe("End-to-End Linting", () => {
 
     expect(allViolations.length).toBeGreaterThan(0);
     expect(allViolations[0].ruleId).toBe("oak-resource-naming-001");
+
+    // check for non nested violation in the nested subdirectory
+    const nonNestedViolation = allViolations.find((v) => !v.filePath.includes("nested/"));
+    expect(nonNestedViolation).toBeDefined();
+    expect(nonNestedViolation?.ruleId).toBe("oak-resource-naming-001");
+
+    // check for violation in the nested subdirectory
+    const nestedViolation = allViolations.find((v) => v.filePath.includes("nested/"));
+    expect(nestedViolation).toBeDefined();
+    expect(nestedViolation?.ruleId).toBe("oak-resource-naming-001");
   });
 
   test("passes clean Terraform files", async () => {

--- a/oak-terraform-linter/tests/integration/end-to-end.test.ts
+++ b/oak-terraform-linter/tests/integration/end-to-end.test.ts
@@ -8,93 +8,64 @@ describe("End-to-End Linting", () => {
   const parser = new TerraformParser();
 
   test("detects naming violations in fixture directory", async () => {
-    const fixtureDir = path.join(
-      __dirname,
-      "../integration/fixtures/naming-violations",
-    );
+    const fixtureDir = path.join(__dirname, "../integration/fixtures/naming-violations");
     const contexts = await parser.parseDirectory(fixtureDir);
 
     const engine = new RulesEngine();
     engine.registerRule(new ResourceNamingRule());
 
     const executionContext: ExecutionContext = { isPrivateRepo: false };
-    const allViolations = contexts.flatMap((ctx) =>
-      engine.executeRules(ctx, executionContext),
-    );
+    const allViolations = contexts.flatMap((ctx) => engine.executeRules(ctx, executionContext));
 
     expect(allViolations.length).toBeGreaterThan(0);
     expect(allViolations[0].ruleId).toBe("oak-resource-naming-001");
   });
 
   test("passes clean Terraform files", async () => {
-    const fixtureDir = path.join(
-      __dirname,
-      "../integration/fixtures/valid-terraform",
-    );
+    const fixtureDir = path.join(__dirname, "../integration/fixtures/valid-terraform");
     const contexts = await parser.parseDirectory(fixtureDir);
 
     const engine = new RulesEngine();
     engine.registerRule(new ResourceNamingRule());
 
     const executionContext: ExecutionContext = { isPrivateRepo: false };
-    const allViolations = contexts.flatMap((ctx) =>
-      engine.executeRules(ctx, executionContext),
-    );
+    const allViolations = contexts.flatMap((ctx) => engine.executeRules(ctx, executionContext));
 
     expect(allViolations).toHaveLength(0);
   });
 
   test("processes multiple files", async () => {
-    const fixtureDir = path.join(
-      __dirname,
-      "../integration/fixtures/valid-terraform",
-    );
+    const fixtureDir = path.join(__dirname, "../integration/fixtures/valid-terraform");
     const contexts = await parser.parseDirectory(fixtureDir);
 
     expect(contexts.length).toBeGreaterThan(1);
   });
 
   test("loads and applies rules from strict config", async () => {
-    const fixtureDir = path.join(
-      __dirname,
-      "../integration/fixtures/naming-violations",
-    );
-    const configPath = path.join(
-      __dirname,
-      "../integration/configs/naming-strict.json",
-    );
+    const fixtureDir = path.join(__dirname, "../integration/fixtures/naming-violations");
+    const configPath = path.join(__dirname, "../integration/configs/naming-strict.json");
     const contexts = await parser.parseDirectory(fixtureDir);
 
     const engine = new RulesEngine();
     await engine.loadRules(configPath);
 
     const executionContext: ExecutionContext = { isPrivateRepo: false };
-    const allViolations = contexts.flatMap((ctx) =>
-      engine.executeRules(ctx, executionContext),
-    );
+    const allViolations = contexts.flatMap((ctx) => engine.executeRules(ctx, executionContext));
 
     expect(allViolations.length).toBeGreaterThan(0);
     expect(allViolations[0].ruleId).toBe("oak-resource-naming-001");
   });
 
   test("loads and respects disabled rules from config", async () => {
-    const fixtureDir = path.join(
-      __dirname,
-      "../integration/fixtures/naming-violations",
-    );
-    const configPath = path.join(
-      __dirname,
-      "../integration/configs/naming-relaxed.json",
-    );
+    const fixtureDir = path.join(__dirname, "../integration/fixtures/naming-violations");
+    const configPath = path.join(__dirname, "../integration/configs/naming-relaxed.json");
     const contexts = await parser.parseDirectory(fixtureDir);
 
     const engine = new RulesEngine();
     await engine.loadRules(configPath);
 
     const executionContext: ExecutionContext = { isPrivateRepo: false };
-    const allViolations = contexts.flatMap((ctx) =>
-      engine.executeRules(ctx, executionContext),
-    );
+    const allViolations = contexts.flatMap((ctx) => engine.executeRules(ctx, executionContext));
 
     // No violations because the naming rule is disabled in the config
     expect(allViolations).toHaveLength(0);

--- a/oak-terraform-linter/tests/integration/end-to-end.test.ts
+++ b/oak-terraform-linter/tests/integration/end-to-end.test.ts
@@ -1,0 +1,73 @@
+import * as path from "path";
+import { TerraformParser } from "../../src/core/parser";
+import { RulesEngine } from "../../src/rules/engine";
+import { ExecutionContext } from "../../src/core/types";
+import { ResourceNamingRule } from "../../src/rules/rule-resource-naming";
+
+describe("End-to-End Linting", () => {
+  const parser = new TerraformParser();
+
+  test("detects naming violations in fixture directory", async () => {
+    const fixtureDir = path.join(__dirname, "../integration/fixtures/naming-violations");
+    const contexts = await parser.parseDirectory(fixtureDir);
+
+    const engine = new RulesEngine();
+    engine.registerRule(new ResourceNamingRule());
+
+    const executionContext: ExecutionContext = { isPrivateRepo: false };
+    const allViolations = contexts.flatMap((ctx) => engine.executeRules(ctx, executionContext));
+
+    expect(allViolations.length).toBeGreaterThan(0);
+    expect(allViolations[0].ruleId).toBe("oak-resource-naming-001");
+  });
+
+  test("passes clean Terraform files", async () => {
+    const fixtureDir = path.join(__dirname, "../integration/fixtures/valid-terraform");
+    const contexts = await parser.parseDirectory(fixtureDir);
+
+    const engine = new RulesEngine();
+    engine.registerRule(new ResourceNamingRule());
+
+    const executionContext: ExecutionContext = { isPrivateRepo: false };
+    const allViolations = contexts.flatMap((ctx) => engine.executeRules(ctx, executionContext));
+
+    expect(allViolations).toHaveLength(0);
+  });
+
+  test("processes multiple files", async () => {
+    const fixtureDir = path.join(__dirname, "../integration/fixtures/valid-terraform");
+    const contexts = await parser.parseDirectory(fixtureDir);
+
+    expect(contexts.length).toBeGreaterThan(1);
+  });
+
+  test("loads and applies rules from strict config", async () => {
+    const fixtureDir = path.join(__dirname, "../integration/fixtures/naming-violations");
+    const configPath = path.join(__dirname, "../integration/configs/naming-strict.json");
+    const contexts = await parser.parseDirectory(fixtureDir);
+
+    const engine = new RulesEngine();
+    await engine.loadRules(configPath);
+
+    const executionContext: ExecutionContext = { isPrivateRepo: false };
+    const allViolations = contexts.flatMap((ctx) => engine.executeRules(ctx, executionContext));
+
+    expect(allViolations.length).toBeGreaterThan(0);
+    expect(allViolations[0].ruleId).toBe("oak-resource-naming-001");
+  });
+
+  test("loads and respects disabled rules from config", async () => {
+    const fixtureDir = path.join(__dirname, "../integration/fixtures/naming-violations");
+    const configPath = path.join(__dirname, "../integration/configs/naming-relaxed.json");
+    const contexts = await parser.parseDirectory(fixtureDir);
+
+    const engine = new RulesEngine();
+    await engine.loadRules(configPath);
+
+    const executionContext: ExecutionContext = { isPrivateRepo: false };
+    const allViolations = contexts.flatMap((ctx) => engine.executeRules(ctx, executionContext));
+
+    // No violations because the naming rule is disabled in the config
+    expect(allViolations).toHaveLength(0);
+  });
+});

--- a/oak-terraform-linter/tests/integration/fixtures/naming-violations/bad-naming.tf
+++ b/oak-terraform-linter/tests/integration/fixtures/naming-violations/bad-naming.tf
@@ -1,0 +1,7 @@
+resource "aws_s3_bucket" "InvalidName" {
+  bucket = "my-test-bucket"
+}
+
+resource "aws_dynamodb_table" "AnotherInvalidName" {
+  name = "test-table"
+}

--- a/oak-terraform-linter/tests/integration/fixtures/naming-violations/nested/bad-naming-nested.tf
+++ b/oak-terraform-linter/tests/integration/fixtures/naming-violations/nested/bad-naming-nested.tf
@@ -1,0 +1,7 @@
+resource "aws_s3_bucket" "InvalidName" {
+  bucket = "my-test-bucket"
+}
+
+resource "aws_dynamodb_table" "AnotherInvalidName" {
+  name = "test-table"
+}

--- a/oak-terraform-linter/tests/integration/fixtures/valid-terraform/good-naming.tf
+++ b/oak-terraform-linter/tests/integration/fixtures/valid-terraform/good-naming.tf
@@ -1,0 +1,7 @@
+resource "aws_s3_bucket" "example_bucket" {
+  bucket = "my-test-bucket"
+}
+
+resource "aws_dynamodb_table" "example_table" {
+  name = "test-table"
+}

--- a/oak-terraform-linter/tests/integration/fixtures/valid-terraform/outputs.tf
+++ b/oak-terraform-linter/tests/integration/fixtures/valid-terraform/outputs.tf
@@ -1,0 +1,8 @@
+output "bucket_name" {
+  value = aws_s3_bucket.example_bucket.id
+  description = "Name of the S3 bucket"
+}
+
+output "table_name" {
+  value = aws_dynamodb_table.example_table.name
+}

--- a/oak-terraform-linter/tests/integration/fixtures/valid-terraform/variables.tf
+++ b/oak-terraform-linter/tests/integration/fixtures/valid-terraform/variables.tf
@@ -1,0 +1,10 @@
+variable "environment" {
+  type = string
+  default = "dev"
+  description = "Environment name"
+}
+
+variable "region" {
+  type = string
+  default = "us-east-1"
+}

--- a/oak-terraform-linter/tests/unit/parser.test.ts
+++ b/oak-terraform-linter/tests/unit/parser.test.ts
@@ -35,7 +35,10 @@ describe("TerraformParser", () => {
     const variables = hcl.variable as Record<string, unknown>;
     expect(variables.environment).toBeDefined();
 
-    const environment = (variables.environment as unknown[])[0] as Record<string, unknown>;
+    const environment = (variables.environment as unknown[])[0] as Record<
+      string,
+      unknown
+    >;
     expect(environment.type).toBe("${string}");
     expect(environment.default).toBe("dev");
     expect(environment.description).toBe("Environment name");
@@ -68,8 +71,12 @@ describe("TerraformParser", () => {
       fs.rmSync(tempDir, { recursive: true });
 
       expect(contexts.length).toBe(2);
-      expect(contexts.map((c) => path.basename(c.filePath))).toContain("root.tf");
-      expect(contexts.map((c) => path.basename(c.filePath))).toContain("nested.tf");
+      expect(contexts.map((c) => path.basename(c.filePath))).toContain(
+        "root.tf",
+      );
+      expect(contexts.map((c) => path.basename(c.filePath))).toContain(
+        "nested.tf",
+      );
 
       // Verify HCL output for each parsed file
       contexts.forEach((context) => {
@@ -85,7 +92,10 @@ describe("TerraformParser", () => {
         const vpcResources = resources.aws_vpc as Record<string, unknown>;
         expect(vpcResources.main).toBeDefined();
 
-        const mainVpc = (vpcResources.main as unknown[])[0] as Record<string, unknown>;
+        const mainVpc = (vpcResources.main as unknown[])[0] as Record<
+          string,
+          unknown
+        >;
         expect(mainVpc.cidr_block).toBe("10.0.0.0/16");
       });
     });
@@ -95,17 +105,24 @@ describe("TerraformParser", () => {
       const validFile = path.join(tempDir, "valid.tf");
       const invalidFile = path.join(tempDir, "invalid.tf");
 
-      fs.writeFileSync(validFile, `resource "aws_vpc" "main" { cidr_block = "10.0.0.0/16" }`);
+      fs.writeFileSync(
+        validFile,
+        `resource "aws_vpc" "main" { cidr_block = "10.0.0.0/16" }`,
+      );
       fs.writeFileSync(invalidFile, "invalid hcl2 syntax {{{");
 
-      await expect(parser.parseDirectory(tempDir)).rejects.toThrow(/Failed to parse .*invalid\.tf/);
+      await expect(parser.parseDirectory(tempDir)).rejects.toThrow(
+        /Failed to parse .*invalid\.tf/,
+      );
 
       // Cleanup
       fs.rmSync(tempDir, { recursive: true });
     });
 
     test("handles empty directory", async () => {
-      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "parser-test-empty-"));
+      const tempDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "parser-test-empty-"),
+      );
       const contexts = await parser.parseDirectory(tempDir);
 
       // Cleanup
@@ -115,7 +132,9 @@ describe("TerraformParser", () => {
     });
 
     test("parses files concurrently in batches", async () => {
-      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "parser-test-concurrent-"));
+      const tempDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "parser-test-concurrent-"),
+      );
       const tfContent = `resource "aws_vpc" "main" { cidr_block = "10.0.0.0/16" }`;
 
       // Create multiple files to test concurrent parsing
@@ -144,7 +163,10 @@ describe("TerraformParser", () => {
         const vpcResources = resources.aws_vpc as Record<string, unknown>;
         expect(vpcResources.main).toBeDefined();
 
-        const mainVpc = (vpcResources.main as unknown[])[0] as Record<string, unknown>;
+        const mainVpc = (vpcResources.main as unknown[])[0] as Record<
+          string,
+          unknown
+        >;
         expect(mainVpc.cidr_block).toBe("10.0.0.0/16");
       });
     });

--- a/oak-terraform-linter/tests/unit/parser.test.ts
+++ b/oak-terraform-linter/tests/unit/parser.test.ts
@@ -148,5 +148,147 @@ describe("TerraformParser", () => {
         expect(mainVpc.cidr_block).toBe("10.0.0.0/16");
       });
     });
+
+    test("respects recursive false option", async () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "parser-test-no-recursive-"));
+      const modulesDir = path.join(tempDir, "modules");
+      fs.mkdirSync(modulesDir);
+
+      const tfContent = `resource "aws_vpc" "main" { cidr_block = "10.0.0.0/16" }`;
+      fs.writeFileSync(path.join(tempDir, "root.tf"), tfContent);
+      fs.writeFileSync(path.join(modulesDir, "main.tf"), tfContent);
+
+      const contexts = await parser.parseDirectory(tempDir, { recursive: false });
+
+      // Cleanup
+      fs.rmSync(tempDir, { recursive: true });
+
+      expect(contexts).toHaveLength(1);
+      expect(contexts[0].filePath).toContain("root.tf");
+      expect(contexts[0].filePath).not.toContain("modules");
+    });
+
+    test("skips node_modules directory", async () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "parser-test-node-modules-"));
+      const nodeModulesDir = path.join(tempDir, "node_modules", "package");
+      fs.mkdirSync(nodeModulesDir, { recursive: true });
+
+      const tfContent = `resource "aws_vpc" "main" { cidr_block = "10.0.0.0/16" }`;
+      fs.writeFileSync(path.join(tempDir, "main.tf"), tfContent);
+      fs.writeFileSync(path.join(nodeModulesDir, "index.tf"), tfContent);
+
+      const contexts = await parser.parseDirectory(tempDir);
+
+      // Cleanup
+      fs.rmSync(tempDir, { recursive: true });
+
+      expect(contexts).toHaveLength(1);
+      expect(contexts[0].filePath).toContain("main.tf");
+      expect(contexts[0].filePath).not.toContain("node_modules");
+    });
+
+    test("skips dot-directories", async () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "parser-test-dot-dirs-"));
+      const gitDir = path.join(tempDir, ".git");
+      const terraformDir = path.join(tempDir, ".terraform");
+      const normalDir = path.join(tempDir, "terraform");
+
+      fs.mkdirSync(gitDir);
+      fs.mkdirSync(terraformDir);
+      fs.mkdirSync(normalDir);
+
+      const tfContent = `resource "aws_vpc" "main" { cidr_block = "10.0.0.0/16" }`;
+      fs.writeFileSync(path.join(tempDir, "main.tf"), tfContent);
+      fs.writeFileSync(path.join(gitDir, "config.tf"), tfContent);
+      fs.writeFileSync(path.join(terraformDir, "state.tf"), tfContent);
+      fs.writeFileSync(path.join(normalDir, "vpc.tf"), tfContent);
+
+      const contexts = await parser.parseDirectory(tempDir);
+
+      // Cleanup
+      fs.rmSync(tempDir, { recursive: true });
+
+      expect(contexts).toHaveLength(2); // main.tf + vpc.tf
+      expect(contexts.every((c) => !c.filePath.includes(".git"))).toBe(true);
+      expect(contexts.every((c) => !c.filePath.includes(".terraform"))).toBe(true);
+      expect(contexts.some((c) => c.filePath.includes("terraform/vpc.tf"))).toBe(true);
+    });
+
+    test("combines recursive=false and directory filtering", async () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "parser-test-combined-"));
+      const nodeModulesDir = path.join(tempDir, "node_modules");
+      const terraformDir = path.join(tempDir, ".terraform");
+
+      fs.mkdirSync(nodeModulesDir);
+      fs.mkdirSync(terraformDir);
+
+      const tfContent = `resource "aws_vpc" "main" { cidr_block = "10.0.0.0/16" }`;
+      fs.writeFileSync(path.join(tempDir, "main.tf"), tfContent);
+      fs.writeFileSync(path.join(nodeModulesDir, "main.tf"), tfContent);
+      fs.writeFileSync(path.join(terraformDir, "state.tf"), tfContent);
+
+      const contexts = await parser.parseDirectory(tempDir, { recursive: false });
+
+      // Cleanup
+      fs.rmSync(tempDir, { recursive: true });
+
+      expect(contexts).toHaveLength(1);
+      expect(contexts[0].filePath).toContain("main.tf");
+      expect(contexts[0].filePath).not.toContain("node_modules");
+      expect(contexts[0].filePath).not.toContain(".terraform");
+    });
+
+    test("deeply nested structure with recursive=true", async () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "parser-test-deep-"));
+      const vpcDir = path.join(tempDir, "modules", "vpc");
+      const vpcTfDir = path.join(vpcDir, ".terraform");
+      const computeDir = path.join(tempDir, "modules", "compute");
+      const computeNmDir = path.join(computeDir, "node_modules");
+      const gitDir = path.join(tempDir, ".git");
+
+      // Create all directories
+      fs.mkdirSync(vpcDir, { recursive: true });
+      fs.mkdirSync(vpcTfDir);
+      fs.mkdirSync(computeNmDir, { recursive: true });
+      fs.mkdirSync(gitDir);
+
+      const tfContent = `resource "aws_vpc" "main" { cidr_block = "10.0.0.0/16" }`;
+
+      // Create files
+      fs.writeFileSync(path.join(tempDir, "main.tf"), tfContent);
+      fs.writeFileSync(path.join(vpcDir, "main.tf"), tfContent);
+      fs.writeFileSync(path.join(vpcTfDir, "state.tf"), tfContent);
+      fs.writeFileSync(path.join(computeDir, "main.tf"), tfContent);
+      fs.writeFileSync(path.join(computeNmDir, "package.tf"), tfContent);
+      fs.writeFileSync(path.join(gitDir, "config.tf"), tfContent);
+
+      const contexts = await parser.parseDirectory(tempDir);
+
+      // Cleanup
+      fs.rmSync(tempDir, { recursive: true });
+
+      expect(contexts).toHaveLength(3); // root main.tf + vpc main.tf + compute main.tf
+      expect(contexts.every((c) => !c.filePath.includes(".git"))).toBe(true);
+      expect(contexts.every((c) => !c.filePath.includes("node_modules"))).toBe(true);
+      expect(contexts.every((c) => !c.filePath.includes(".terraform"))).toBe(true);
+    });
+
+    test("defaults to recursive=true when options omitted", async () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "parser-test-defaults-"));
+      const nestedDir = path.join(tempDir, "nested");
+      fs.mkdirSync(nestedDir);
+
+      const tfContent = `resource "aws_vpc" "main" { cidr_block = "10.0.0.0/16" }`;
+      fs.writeFileSync(path.join(tempDir, "root.tf"), tfContent);
+      fs.writeFileSync(path.join(nestedDir, "nested.tf"), tfContent);
+
+      // Call without options parameter
+      const contexts = await parser.parseDirectory(tempDir);
+
+      // Cleanup
+      fs.rmSync(tempDir, { recursive: true });
+
+      expect(contexts).toHaveLength(2); // Should find both (recursive by default)
+    });
   });
 });

--- a/oak-terraform-linter/tests/unit/parser.test.ts
+++ b/oak-terraform-linter/tests/unit/parser.test.ts
@@ -1,0 +1,152 @@
+import { TerraformParser } from "../../src/core/parser";
+import * as path from "path";
+import * as fs from "fs";
+import * as os from "os";
+
+describe("TerraformParser", () => {
+  const parser = new TerraformParser();
+
+  test("parses simple Terraform file", async () => {
+    const content = `
+      resource "aws_s3_bucket" "example" {
+        bucket = "my-bucket"
+      }
+    `;
+    const context = await parser.parseContent(content, "test.tf");
+    expect(context.hcl).toBeDefined();
+    expect(context.filePath).toBe("test.tf");
+    expect(context.fileContent).toBe(content);
+  });
+
+  test("parses variables", async () => {
+    const content = `
+      variable "environment" {
+        type = string
+        default = "dev"
+        description = "Environment name"
+      }
+    `;
+    const context = await parser.parseContent(content, "test.tf");
+    expect(context.hcl).toBeDefined();
+
+    const hcl = context.hcl as Record<string, unknown>;
+    expect(hcl.variable).toBeDefined();
+
+    const variables = hcl.variable as Record<string, unknown>;
+    expect(variables.environment).toBeDefined();
+
+    const environment = (variables.environment as unknown[])[0] as Record<string, unknown>;
+    expect(environment.type).toBe("${string}");
+    expect(environment.default).toBe("dev");
+    expect(environment.description).toBe("Environment name");
+
+    expect(context.filePath).toBe("test.tf");
+  });
+
+  test("throws error on invalid HCL2", async () => {
+    const content = `invalid hcl2 syntax {{{`;
+    await expect(parser.parseContent(content, "bad.tf")).rejects.toThrow();
+  });
+
+  describe("parseDirectory", () => {
+    test("parses .tf files from nested directories", async () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "parser-test-"));
+      const nestedDir = path.join(tempDir, "nested");
+      fs.mkdirSync(nestedDir);
+
+      // Create test files at different levels
+      const rootFile = path.join(tempDir, "root.tf");
+      const nestedFile = path.join(nestedDir, "nested.tf");
+      const tfContent = `resource "aws_vpc" "main" { cidr_block = "10.0.0.0/16" }`;
+
+      fs.writeFileSync(rootFile, tfContent);
+      fs.writeFileSync(nestedFile, tfContent);
+
+      const contexts = await parser.parseDirectory(tempDir);
+
+      // Cleanup
+      fs.rmSync(tempDir, { recursive: true });
+
+      expect(contexts.length).toBe(2);
+      expect(contexts.map((c) => path.basename(c.filePath))).toContain("root.tf");
+      expect(contexts.map((c) => path.basename(c.filePath))).toContain("nested.tf");
+
+      // Verify HCL output for each parsed file
+      contexts.forEach((context) => {
+        expect(context.hcl).toBeDefined();
+        expect(context.fileContent).toBeDefined();
+
+        const hcl = context.hcl as Record<string, unknown>;
+        expect(hcl.resource).toBeDefined();
+
+        const resources = hcl.resource as Record<string, unknown>;
+        expect(resources.aws_vpc).toBeDefined();
+
+        const vpcResources = resources.aws_vpc as Record<string, unknown>;
+        expect(vpcResources.main).toBeDefined();
+
+        const mainVpc = (vpcResources.main as unknown[])[0] as Record<string, unknown>;
+        expect(mainVpc.cidr_block).toBe("10.0.0.0/16");
+      });
+    });
+
+    test("throws descriptive error when any file fails to parse", async () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "parser-test-"));
+      const validFile = path.join(tempDir, "valid.tf");
+      const invalidFile = path.join(tempDir, "invalid.tf");
+
+      fs.writeFileSync(validFile, `resource "aws_vpc" "main" { cidr_block = "10.0.0.0/16" }`);
+      fs.writeFileSync(invalidFile, "invalid hcl2 syntax {{{");
+
+      await expect(parser.parseDirectory(tempDir)).rejects.toThrow(/Failed to parse .*invalid\.tf/);
+
+      // Cleanup
+      fs.rmSync(tempDir, { recursive: true });
+    });
+
+    test("handles empty directory", async () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "parser-test-empty-"));
+      const contexts = await parser.parseDirectory(tempDir);
+
+      // Cleanup
+      fs.rmSync(tempDir, { recursive: true });
+
+      expect(contexts).toEqual([]);
+    });
+
+    test("parses files concurrently in batches", async () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "parser-test-concurrent-"));
+      const tfContent = `resource "aws_vpc" "main" { cidr_block = "10.0.0.0/16" }`;
+
+      // Create multiple files to test concurrent parsing
+      for (let i = 0; i < 15; i++) {
+        fs.writeFileSync(path.join(tempDir, `file${i}.tf`), tfContent);
+      }
+
+      const contexts = await parser.parseDirectory(tempDir);
+
+      // Cleanup
+      fs.rmSync(tempDir, { recursive: true });
+
+      expect(contexts.length).toBe(15);
+      contexts.forEach((context) => {
+        expect(context.hcl).toBeDefined();
+        expect(context.filePath.endsWith(".tf")).toBe(true);
+        expect(context.fileContent).toBe(tfContent);
+
+        // Validate the complete HCL structure
+        const hcl = context.hcl as Record<string, unknown>;
+        expect(hcl.resource).toBeDefined();
+
+        const resources = hcl.resource as Record<string, unknown>;
+        expect(resources.aws_vpc).toBeDefined();
+
+        const vpcResources = resources.aws_vpc as Record<string, unknown>;
+        expect(vpcResources.main).toBeDefined();
+
+        const mainVpc = (vpcResources.main as unknown[])[0] as Record<string, unknown>;
+        expect(mainVpc.cidr_block).toBe("10.0.0.0/16");
+      });
+    });
+  });
+});

--- a/oak-terraform-linter/tests/unit/parser.test.ts
+++ b/oak-terraform-linter/tests/unit/parser.test.ts
@@ -35,10 +35,7 @@ describe("TerraformParser", () => {
     const variables = hcl.variable as Record<string, unknown>;
     expect(variables.environment).toBeDefined();
 
-    const environment = (variables.environment as unknown[])[0] as Record<
-      string,
-      unknown
-    >;
+    const environment = (variables.environment as unknown[])[0] as Record<string, unknown>;
     expect(environment.type).toBe("${string}");
     expect(environment.default).toBe("dev");
     expect(environment.description).toBe("Environment name");
@@ -71,12 +68,8 @@ describe("TerraformParser", () => {
       fs.rmSync(tempDir, { recursive: true });
 
       expect(contexts.length).toBe(2);
-      expect(contexts.map((c) => path.basename(c.filePath))).toContain(
-        "root.tf",
-      );
-      expect(contexts.map((c) => path.basename(c.filePath))).toContain(
-        "nested.tf",
-      );
+      expect(contexts.map((c) => path.basename(c.filePath))).toContain("root.tf");
+      expect(contexts.map((c) => path.basename(c.filePath))).toContain("nested.tf");
 
       // Verify HCL output for each parsed file
       contexts.forEach((context) => {
@@ -92,10 +85,7 @@ describe("TerraformParser", () => {
         const vpcResources = resources.aws_vpc as Record<string, unknown>;
         expect(vpcResources.main).toBeDefined();
 
-        const mainVpc = (vpcResources.main as unknown[])[0] as Record<
-          string,
-          unknown
-        >;
+        const mainVpc = (vpcResources.main as unknown[])[0] as Record<string, unknown>;
         expect(mainVpc.cidr_block).toBe("10.0.0.0/16");
       });
     });
@@ -105,24 +95,17 @@ describe("TerraformParser", () => {
       const validFile = path.join(tempDir, "valid.tf");
       const invalidFile = path.join(tempDir, "invalid.tf");
 
-      fs.writeFileSync(
-        validFile,
-        `resource "aws_vpc" "main" { cidr_block = "10.0.0.0/16" }`,
-      );
+      fs.writeFileSync(validFile, `resource "aws_vpc" "main" { cidr_block = "10.0.0.0/16" }`);
       fs.writeFileSync(invalidFile, "invalid hcl2 syntax {{{");
 
-      await expect(parser.parseDirectory(tempDir)).rejects.toThrow(
-        /Failed to parse .*invalid\.tf/,
-      );
+      await expect(parser.parseDirectory(tempDir)).rejects.toThrow(/Failed to parse .*invalid\.tf/);
 
       // Cleanup
       fs.rmSync(tempDir, { recursive: true });
     });
 
     test("handles empty directory", async () => {
-      const tempDir = fs.mkdtempSync(
-        path.join(os.tmpdir(), "parser-test-empty-"),
-      );
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "parser-test-empty-"));
       const contexts = await parser.parseDirectory(tempDir);
 
       // Cleanup
@@ -132,9 +115,7 @@ describe("TerraformParser", () => {
     });
 
     test("parses files concurrently in batches", async () => {
-      const tempDir = fs.mkdtempSync(
-        path.join(os.tmpdir(), "parser-test-concurrent-"),
-      );
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "parser-test-concurrent-"));
       const tfContent = `resource "aws_vpc" "main" { cidr_block = "10.0.0.0/16" }`;
 
       // Create multiple files to test concurrent parsing
@@ -163,10 +144,7 @@ describe("TerraformParser", () => {
         const vpcResources = resources.aws_vpc as Record<string, unknown>;
         expect(vpcResources.main).toBeDefined();
 
-        const mainVpc = (vpcResources.main as unknown[])[0] as Record<
-          string,
-          unknown
-        >;
+        const mainVpc = (vpcResources.main as unknown[])[0] as Record<string, unknown>;
         expect(mainVpc.cidr_block).toBe("10.0.0.0/16");
       });
     });

--- a/oak-terraform-linter/tests/unit/reporters.test.ts
+++ b/oak-terraform-linter/tests/unit/reporters.test.ts
@@ -15,9 +15,7 @@ describe("HumanReporter", () => {
 
   test("reports no violations message", () => {
     reporter.report([], { strict: false, fileCount: 1 });
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining("No violations"),
-    );
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("No violations"));
   });
 
   test("groups violations by file", () => {
@@ -39,12 +37,8 @@ describe("HumanReporter", () => {
     ];
 
     reporter.report(violations, { strict: false, fileCount: 2 });
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining("file1.tf"),
-    );
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining("file2.tf"),
-    );
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("file1.tf"));
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("file2.tf"));
   });
 
   test("summarizes violations", () => {
@@ -67,9 +61,7 @@ describe("HumanReporter", () => {
 
     reporter.report(violations, { strict: false, fileCount: 1 });
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("1 error"));
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining("1 warning"),
-    );
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("1 warning"));
   });
 
   test("includes suggestions when available", () => {
@@ -85,9 +77,7 @@ describe("HumanReporter", () => {
     ];
 
     reporter.report(violations, { strict: false, fileCount: 1 });
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Use this instead"),
-    );
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Use this instead"));
   });
 
   test("handles info severity violations", () => {
@@ -103,9 +93,7 @@ describe("HumanReporter", () => {
 
     reporter.report(violations, { strict: false, fileCount: 1 });
     // Should print the info violation with ℹ icon
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining("Info message"),
-    );
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Info message"));
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("ℹ"));
   });
 

--- a/oak-terraform-linter/tests/unit/reporters.test.ts
+++ b/oak-terraform-linter/tests/unit/reporters.test.ts
@@ -1,0 +1,117 @@
+import { HumanReporter } from "../../src/reporters/human";
+import { LintViolation } from "../../src/core/types";
+
+describe("HumanReporter", () => {
+  let consoleSpy: jest.SpyInstance;
+  const reporter = new HumanReporter();
+
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, "log").mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  test("reports no violations message", () => {
+    reporter.report([], { strict: false, fileCount: 1 });
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("No violations"));
+  });
+
+  test("groups violations by file", () => {
+    const violations: LintViolation[] = [
+      {
+        ruleId: "rule-1",
+        ruleName: "Rule 1",
+        severity: "error",
+        message: "Error 1",
+        filePath: "file1.tf",
+      },
+      {
+        ruleId: "rule-2",
+        ruleName: "Rule 2",
+        severity: "warning",
+        message: "Warning 1",
+        filePath: "file2.tf",
+      },
+    ];
+
+    reporter.report(violations, { strict: false, fileCount: 2 });
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("file1.tf"));
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("file2.tf"));
+  });
+
+  test("summarizes violations", () => {
+    const violations: LintViolation[] = [
+      {
+        ruleId: "rule-1",
+        ruleName: "Rule 1",
+        severity: "error",
+        message: "Error",
+        filePath: "test.tf",
+      },
+      {
+        ruleId: "rule-2",
+        ruleName: "Rule 2",
+        severity: "warning",
+        message: "Warning",
+        filePath: "test.tf",
+      },
+    ];
+
+    reporter.report(violations, { strict: false, fileCount: 1 });
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("1 error"));
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("1 warning"));
+  });
+
+  test("includes suggestions when available", () => {
+    const violations: LintViolation[] = [
+      {
+        ruleId: "rule-1",
+        ruleName: "Rule 1",
+        severity: "error",
+        message: "Error",
+        filePath: "test.tf",
+        suggestion: "Use this instead",
+      },
+    ];
+
+    reporter.report(violations, { strict: false, fileCount: 1 });
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Use this instead"));
+  });
+
+  test("handles info severity violations", () => {
+    const violations: LintViolation[] = [
+      {
+        ruleId: "rule-1",
+        ruleName: "Rule 1",
+        severity: "info",
+        message: "Info message",
+        filePath: "test.tf",
+      },
+    ];
+
+    reporter.report(violations, { strict: false, fileCount: 1 });
+    // Should print the info violation with ℹ icon
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Info message"));
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("ℹ"));
+  });
+
+  test("handles unknown severity gracefully", () => {
+    const violations: LintViolation[] = [
+      {
+        ruleId: "rule-1",
+        ruleName: "Rule 1",
+        severity: "unknown" as "error",
+        message: "Unknown severity",
+        filePath: "test.tf",
+      },
+    ];
+
+    // Should not throw and should output something
+    expect(() => {
+      reporter.report(violations, { strict: false, fileCount: 1 });
+    }).not.toThrow();
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+});

--- a/oak-terraform-linter/tests/unit/reporters.test.ts
+++ b/oak-terraform-linter/tests/unit/reporters.test.ts
@@ -15,7 +15,9 @@ describe("HumanReporter", () => {
 
   test("reports no violations message", () => {
     reporter.report([], { strict: false, fileCount: 1 });
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("No violations"));
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("No violations"),
+    );
   });
 
   test("groups violations by file", () => {
@@ -37,8 +39,12 @@ describe("HumanReporter", () => {
     ];
 
     reporter.report(violations, { strict: false, fileCount: 2 });
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("file1.tf"));
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("file2.tf"));
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("file1.tf"),
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("file2.tf"),
+    );
   });
 
   test("summarizes violations", () => {
@@ -61,7 +67,9 @@ describe("HumanReporter", () => {
 
     reporter.report(violations, { strict: false, fileCount: 1 });
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("1 error"));
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("1 warning"));
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("1 warning"),
+    );
   });
 
   test("includes suggestions when available", () => {
@@ -77,7 +85,9 @@ describe("HumanReporter", () => {
     ];
 
     reporter.report(violations, { strict: false, fileCount: 1 });
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Use this instead"));
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Use this instead"),
+    );
   });
 
   test("handles info severity violations", () => {
@@ -93,7 +103,9 @@ describe("HumanReporter", () => {
 
     reporter.report(violations, { strict: false, fileCount: 1 });
     // Should print the info violation with ℹ icon
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Info message"));
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Info message"),
+    );
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("ℹ"));
   });
 

--- a/oak-terraform-linter/tests/unit/rule-loader.test.ts
+++ b/oak-terraform-linter/tests/unit/rule-loader.test.ts
@@ -98,8 +98,6 @@ describe("RuleLoader", () => {
     const rules = await loader.loadRulesFromFile(configPath);
     expect(rules).toHaveLength(1);
     expect(rules[0].params).toBeDefined();
-    expect((rules[0].params as Record<string, unknown>).customParam).toBe(
-      "custom-value",
-    );
+    expect((rules[0].params as Record<string, unknown>).customParam).toBe("custom-value");
   });
 });

--- a/oak-terraform-linter/tests/unit/rule-loader.test.ts
+++ b/oak-terraform-linter/tests/unit/rule-loader.test.ts
@@ -1,0 +1,103 @@
+import { RuleLoader } from "../../src/rules/loader";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+describe("RuleLoader", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "rule-loader-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true });
+  });
+
+  test("loads rules from valid config file", async () => {
+    const configPath = path.join(tempDir, "rules.json");
+    const config = {
+      rules: [
+        {
+          ruleType: "helper-always-passes",
+          enabled: true,
+        },
+      ],
+    };
+    fs.writeFileSync(configPath, JSON.stringify(config));
+
+    const loader = new RuleLoader();
+    const rules = await loader.loadRulesFromFile(configPath);
+    expect(rules).toHaveLength(1);
+    expect(rules[0].id).toBe("oak-helper-pass-001");
+  });
+
+  test("skips disabled rules", async () => {
+    const configPath = path.join(tempDir, "rules.json");
+    const config = {
+      rules: [
+        {
+          ruleType: "helper-always-passes",
+          enabled: false,
+        },
+      ],
+    };
+    fs.writeFileSync(configPath, JSON.stringify(config));
+
+    const loader = new RuleLoader();
+    const rules = await loader.loadRulesFromFile(configPath);
+    expect(rules).toHaveLength(0);
+  });
+
+  test("loads default rules", () => {
+    const loader = new RuleLoader();
+    const rules = loader.loadDefaultRules();
+    expect(rules.length).toBeGreaterThan(0);
+  });
+
+  test("throws on missing rule type", async () => {
+    const configPath = path.join(tempDir, "rules.json");
+    const config = {
+      rules: [
+        {
+          ruleType: "non-existent-rule",
+          enabled: true,
+        },
+      ],
+    };
+    fs.writeFileSync(configPath, JSON.stringify(config));
+
+    const loader = new RuleLoader();
+    await expect(loader.loadRulesFromFile(configPath)).rejects.toThrow();
+  });
+
+  test("throws on invalid JSON", async () => {
+    const configPath = path.join(tempDir, "rules.json");
+    fs.writeFileSync(configPath, "invalid json {{{");
+
+    const loader = new RuleLoader();
+    await expect(loader.loadRulesFromFile(configPath)).rejects.toThrow();
+  });
+
+  test("loads custom params into rule from config", async () => {
+    const configPath = path.join(tempDir, "rules.json");
+    const config = {
+      rules: [
+        {
+          ruleType: "helper-always-passes",
+          enabled: true,
+          params: {
+            customParam: "custom-value",
+          },
+        },
+      ],
+    };
+    fs.writeFileSync(configPath, JSON.stringify(config));
+
+    const loader = new RuleLoader();
+    const rules = await loader.loadRulesFromFile(configPath);
+    expect(rules).toHaveLength(1);
+    expect(rules[0].params).toBeDefined();
+    expect((rules[0].params as Record<string, unknown>).customParam).toBe("custom-value");
+  });
+});

--- a/oak-terraform-linter/tests/unit/rule-loader.test.ts
+++ b/oak-terraform-linter/tests/unit/rule-loader.test.ts
@@ -98,6 +98,8 @@ describe("RuleLoader", () => {
     const rules = await loader.loadRulesFromFile(configPath);
     expect(rules).toHaveLength(1);
     expect(rules[0].params).toBeDefined();
-    expect((rules[0].params as Record<string, unknown>).customParam).toBe("custom-value");
+    expect((rules[0].params as Record<string, unknown>).customParam).toBe(
+      "custom-value",
+    );
   });
 });

--- a/oak-terraform-linter/tests/unit/rule-resource-naming.test.ts
+++ b/oak-terraform-linter/tests/unit/rule-resource-naming.test.ts
@@ -1,0 +1,82 @@
+import { ResourceNamingRule } from "../../src/rules/rule-resource-naming";
+import { TerraformFileContext } from "../../src/core/types";
+
+describe("ResourceNamingRule", () => {
+  const rule = new ResourceNamingRule();
+
+  test("detects invalid naming patterns", () => {
+    const context: TerraformFileContext = {
+      hcl: {
+        resource: {
+          aws_s3_bucket: {
+            InvalidName: [
+              {
+                bucket: "my-bucket",
+              },
+            ],
+          },
+        },
+      },
+      filePath: "test.tf",
+      fileContent: "",
+    };
+
+    const violations = rule.validate(context, {});
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toContain("InvalidName");
+  });
+
+  test("accepts valid naming patterns", () => {
+    const context: TerraformFileContext = {
+      hcl: {
+        resource: {
+          aws_s3_bucket: {
+            valid_name: [
+              {
+                bucket: "my-bucket",
+              },
+            ],
+          },
+        },
+      },
+      filePath: "test.tf",
+      fileContent: "",
+    };
+
+    const violations = rule.validate(context, {});
+    expect(violations).toHaveLength(0);
+  });
+
+  test("handles missing resources", () => {
+    const context: TerraformFileContext = {
+      hcl: {},
+      filePath: "test.tf",
+      fileContent: "",
+    };
+
+    const violations = rule.validate(context, {});
+    expect(violations).toHaveLength(0);
+  });
+
+  test("provides suggestions for invalid names", () => {
+    const context: TerraformFileContext = {
+      hcl: {
+        resource: {
+          aws_s3_bucket: {
+            "Invalid-Name": [
+              {
+                bucket: "my-bucket",
+              },
+            ],
+          },
+        },
+      },
+      filePath: "test.tf",
+      fileContent: "",
+    };
+
+    const violations = rule.validate(context, {});
+    expect(violations[0].suggestion).toBeDefined();
+    expect(violations[0].suggestion).toContain("invalid_name");
+  });
+});

--- a/oak-terraform-linter/tests/unit/rules-engine.test.ts
+++ b/oak-terraform-linter/tests/unit/rules-engine.test.ts
@@ -1,0 +1,64 @@
+import { RulesEngine } from "../../src/rules/engine";
+import { TerraformFileContext } from "../../src/core/types";
+import {
+  HelperPassingRule,
+  HelperFailingRule,
+  HelperErrorRule,
+} from "../../src/rules/rule-helpers";
+
+describe("RulesEngine", () => {
+  test("registers custom rule", () => {
+    const engine = new RulesEngine();
+    const rule = new HelperPassingRule();
+    engine.registerRule(rule);
+    expect(engine.getRules()).toHaveLength(1);
+  });
+
+  test("executes rules against context", () => {
+    const engine = new RulesEngine();
+    engine.registerRule(new HelperFailingRule());
+
+    const context: TerraformFileContext = {
+      hcl: {},
+      filePath: "test.tf",
+      fileContent: "",
+    };
+
+    const violations = engine.executeRules(context, {});
+    expect(violations).toHaveLength(1);
+  });
+
+  test("passes with no rules", () => {
+    const engine = new RulesEngine();
+
+    const context: TerraformFileContext = {
+      hcl: {},
+      filePath: "test.tf",
+      fileContent: "",
+    };
+
+    const violations = engine.executeRules(context, {});
+    expect(violations).toHaveLength(0);
+  });
+
+  test("loads default rules", () => {
+    const engine = new RulesEngine();
+    engine.loadDefaultRules();
+    expect(engine.getRules().length).toBeGreaterThan(0);
+  });
+
+  test("throws errors during rule execution", () => {
+    const engine = new RulesEngine();
+    engine.registerRule(new HelperErrorRule());
+
+    const context: TerraformFileContext = {
+      hcl: {},
+      filePath: "test.tf",
+      fileContent: "",
+    };
+
+    expect(() => {
+      engine.executeRules(context, {});
+    }).toThrow("This rule always errors (for development purposes only)");
+  });
+});


### PR DESCRIPTION
## Description

- This PR contains unit tests and e2e tests for the linter

## About the linter

- These PRs add the typescript package `oak-terraform-linter`. It is an extensible linter that searches for `.tf` files in a path and validates them against a list of rules.
- The intention is for this to eventally be run as a continuous integration step in github actions for all Oak repositories that contain `terraform` configurations.
- These PRs contains only the linter and an example rule. They do not contain any of the rules we wish to apply to the Oak organisation, or any CI configuration to do so. These are planned as further pieces of work (see the Epic for this task in Notion)
- An overview of the architecture and root of the (hopefully succinct) documentation can be found in the [README](https://github.com/oaknational/oak-terraform-actions/blob/65077c86ca08a4c3173e10c8ac50ade86a960bd8/oak-terraform-linter/README.md) at the root of the package.
- Disclosure: In the spirit of the AI surveys that have recently gone out I experimented with the agent workflow described [here](https://boristane.com/blog/how-i-use-claude-code/) to develop this feature.

## Issue(s)

[ENG-1498](https://www.notion.so/Write-a-custom-Terraform-linter-32126cc4e1b18059bf5feaf3d2c0c466)

## How to test

1. See the [README](https://github.com/oaknational/oak-terraform-actions/blob/fe833b60031c21df535d859679f557061d5bc1a8/oak-terraform-linter/examples/README.md) in the examples folder.