### PR TITLE
fix: pin terraform version in checks action

### DIFF
--- a/actions/terraform-checks/action.yml
+++ b/actions/terraform-checks/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: Which base dir to search for the Terraform config(s) in
     required: false
     default: infrastructure
+  terraform_version:
+    description: Which version of Terraform to use for the checks
+    required: false
+    default: v1.14.9
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
## Description

- Downgrade to `v1.14.9` from currently failing latest `v1.15.0`